### PR TITLE
Add tabbed styles to recipe show

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -13,7 +13,7 @@
 
 /* BOOTSTRAP OVERRIDES */
 .card {
-  height: $card_height;
+  // height: $card_height;
   .card-img-top {
     height: $card_image_height;
     background-color: gray;

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -60,20 +60,39 @@
 </div><!-- row -->
 
 <h3>Instructions</h3>
-<ol>
-  <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
-</ol>
+<div class="card mb-5">
+  <div class="card-header">
+    <ul class="nav nav-tabs card-header-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
+      </li>
+    </ul>
+  </div>
+  <div class="card-body">
+    <div class="tab-content" id="myTabContent">
+      <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
+        <ol>
+          <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+        </ol>
+      </div>
 
-<% unless @recipe.prep_day_instructions.blank? %>
-  <h3>Prep Day Instructions</h3>
-  <ol>
-    <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
-  </ol>
-<% end %>
+      <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
+        <ol>
+          <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+        </ol>
+      </div>
 
-<% unless @recipe.reheat_instructions.blank? %>
-  <h3>Reheat Instructions</h3>
-  <ol>
-    <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
-  </ol>
-<% end %>
+      <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
+        <ol>
+          <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
+        </ol>
+      </div>
+    </div><!-- tab-content -->
+  </div><!-- card body -->
+</div><!-- card -->

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -21,6 +21,14 @@ FactoryBot.define do
         'Sunt in culpa qui officia deserunt mollit anim id est laborum.',
       ].join("\n\n")
     }
+    prep_day_instructions {
+      [
+        'On prep day, lorem ipsum dolor sit amet.',
+        'Sint occaecat cupidatat non proident.',
+        'Aliquip ex ea commodo consequat.'
+      ].join("\n\n")
+    }
+
     reheat_instructions {
       [
         'Reheat by lorem ipsum dolor sit amet.',


### PR DESCRIPTION
Closes #31 

This adds the second part of this ticket: the bootstrap tab styles. Now we can see all 3 sets of instructions in one tabbed space.