### PR TITLE
Add star ★ toggle for favoriting shopping lists

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -11,10 +11,14 @@
   padding-top: 1rem;
 }
 
-// Links
+// Links & Icons
 a { color: $link-color;}
 a.icon:link { text-decoration: none; }
 a.back-icon:link { font-size: 1.5rem; }
+
+a.star:link { font-size: 1.25rem; }
+a.star-filled:link, a.star-filled:visited { color: $brand-yellow; }
+a.star-outline:link, a.star-outline:visited { color: $light-gray; }
 
 
 // SEARCH BAR

--- a/app/controllers/completed_shopping_list_items_controller.rb
+++ b/app/controllers/completed_shopping_list_items_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-class ListItemCompletionsController < ApplicationController
+class CompletedShoppingListItemsController < ApplicationController
   before_action :set_shopping_list_item, only: %i[create destroy]
 
   def create
-    @shopping_list_item.mark_as_complete!
+    @shopping_list_item.complete!
     redirect_to shopping_list_url(@shopping_list_item.shopping_list)
   end
 
   def destroy
-    @shopping_list_item.mark_as_uncomplete!
+    @shopping_list_item.uncomplete!
     redirect_to shopping_list_url(@shopping_list_item.shopping_list)
   end
 

--- a/app/controllers/shopping_list_favorites_controller.rb
+++ b/app/controllers/shopping_list_favorites_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ShoppingListFavoritesController < ApplicationController
+  before_action :set_shopping_list, only: %i[create destroy]
+
+  def create
+    @shopping_list.favorite!
+    redirect_to shopping_lists_url
+  end
+
+  def destroy
+    @shopping_list.unfavorite!
+    redirect_to shopping_lists_url
+  end
+
+  private
+
+  def set_shopping_list
+    @shopping_list = ShoppingList.find(params[:id])
+  end
+
+  def shopping_list_params
+    params.require(:shopping_list)
+          .permit(:user_id,
+                  :name,
+                  :favorite)
+  end
+end

--- a/app/controllers/shopping_list_favorites_controller.rb
+++ b/app/controllers/shopping_list_favorites_controller.rb
@@ -4,6 +4,9 @@ class ShoppingListFavoritesController < ApplicationController
   before_action :set_shopping_list, only: %i[create destroy]
 
   def create
+    user = @shopping_list.user
+    user.shopping_lists.each { |list| list.unfavorite! }
+
     @shopping_list.favorite!
     redirect_to shopping_lists_url
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -4,7 +4,7 @@ class ShoppingListsController < ApplicationController
   before_action :set_shopping_list, only: %i[show edit update destroy]
 
   def index
-    @shopping_lists = current_user.shopping_lists.search(params[:search]).by_name
+    @shopping_lists = current_user.shopping_lists.search(params[:search]).by_favorite.by_name
     @shopping_list = current_user.shopping_lists.new
   end
 

--- a/app/helpers/shopping_lists_helper.rb
+++ b/app/helpers/shopping_lists_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ShoppingListsHelper
+  def toggle_favorite(list)
+    if list.favorite
+      # Show the ★ and link to "unfavorite" it
+      link_to '', shopping_list_favorite_path(list),
+                  class: Icon.star_filled,
+                  method: :delete
+    else
+      # Show the ☆ and link to "favorite" it
+      link_to '', shopping_list_favorites_path(id: list.id),
+                  class: Icon.star_outline,
+                  method: :post
+    end
+  end
+end

--- a/app/models/concerns/icon.rb
+++ b/app/models/concerns/icon.rb
@@ -10,4 +10,12 @@ module Icon
   def self.delete
     'icon far fa-trash-alt'
   end
+
+  def self.star_filled # '★'
+    'icon fas fa-star'
+  end
+
+  def self.star_outline # '☆'
+    'icon far fa-star'
+  end
 end

--- a/app/models/concerns/icon.rb
+++ b/app/models/concerns/icon.rb
@@ -12,10 +12,10 @@ module Icon
   end
 
   def self.star_filled # '★'
-    'icon fas fa-star'
+    'icon star star-filled fas fa-star'
   end
 
   def self.star_outline # '☆'
-    'icon far fa-star'
+    'icon star star-outline far fa-star'
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -10,6 +10,10 @@ class ShoppingList < ApplicationRecord
   validates :name,
             presence: true
 
+  def self.by_favorite
+    order(favorite: :desc)
+  end
+
   def favorite!
     self.favorite = true
     self.save!

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -9,4 +9,14 @@ class ShoppingList < ApplicationRecord
 
   validates :name,
             presence: true
+
+  def favorite!
+    self.favorite = true
+    self.save!
+  end
+
+  def unfavorite!
+    self.favorite = false
+    self.save!
+  end
 end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -20,13 +20,13 @@ class ShoppingListItem < ApplicationRecord
   end
 
   # Set the item's purchased setting to true and save the item
-  def mark_as_complete!
+  def complete!
     self.purchased = true
     self.save!
   end
 
   # Set the item's purchased setting to false and save the item
-  def mark_as_uncomplete!
+  def uncomplete!
     self.purchased = false
     self.save!
   end

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -7,6 +7,7 @@
   <% @shopping_lists.each do |shopping_list| %>
     <article class='list'>
       <h3>
+        <%= toggle_favorite(shopping_list) %> 
         <%= link_to shopping_list.name, shopping_list_path(shopping_list) %>
         <span class='list-actions right'>
           <%= link_to "", edit_shopping_list_path(shopping_list), class: Icon.edit %>

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -5,16 +5,14 @@
   <%= render 'form', shopping_list: @shopping_list %>
 
   <% @shopping_lists.each do |shopping_list| %>
-    <article class='list'>
-      <h3>
-        <%= toggle_favorite(shopping_list) %> 
+      <h3 class='list'>
+        <%= toggle_favorite(shopping_list) %>
         <%= link_to shopping_list.name, shopping_list_path(shopping_list) %>
         <span class='list-actions right'>
           <%= link_to "", edit_shopping_list_path(shopping_list), class: Icon.edit %>
           <%= link_to "", shopping_list, method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: Icon.delete %>
         </span>
       </h3>
-    </article>
   <% end %>
 
 <% else %>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -7,13 +7,13 @@
   <%= link_to 'Add an Item...', new_shopping_list_shopping_list_item_path(@shopping_list) %>
 </article>
 
-<% @shopping_list.shopping_list_items.includes(:aisle).not_purchased.group_by(&:aisle).each do |aisle, items| %>
+<% @shopping_list.shopping_list_items.order(:aisle_id).includes(:aisle).not_purchased.group_by(&:aisle).each do |aisle, items| %>
   <% if aisle %>
     <h4 class='aisle'><%= aisle.number %> <%= aisle.name %></h4>
     <% items.each do |item| %>
       <article class='list'>
         <p class='list-item'>
-          <%= link_to "#{item.quantity} #{item.name}", list_item_completions_path(id: item.id), method: :post %>
+          <%= link_to "#{item.quantity} #{item.name}", completed_shopping_list_items_path(id: item.id), method: :post %>
           <span class='right'> <%= link_to "", edit_shopping_list_shopping_list_item_path(@shopping_list, item), class: Icon.edit %></span>
         </p>
       </article>
@@ -25,7 +25,7 @@
 <% @shopping_list.shopping_list_items.purchased.by_recently_edited.each do |item| %>
   <article class='list'>
     <p class='list-item item-crossed-off'>
-      <%= link_to "#{item.quantity} #{item.name}", list_item_completion_path(item), method: :delete %>
+      <%= link_to "#{item.quantity} #{item.name}", completed_shopping_list_item_path(item), method: :delete %>
       <%= link_to "", edit_shopping_list_shopping_list_item_path(@shopping_list, item), class: "right #{Icon.edit}" %>
     </p>
   </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     resources :shopping_list_items, only: [:new, :create, :edit, :update, :destroy]
   end
 
-  resources :list_item_completions, only: [:create, :destroy]
+  resources :completed_shopping_list_items, only: [:create, :destroy]
   resources :shopping_list_favorites, only: [:create, :destroy]
 
   get 'mockups/recipes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   resources :shopping_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
     resources :shopping_list_items, only: [:new, :create, :edit, :update, :destroy]
   end
+
   resources :list_item_completions, only: [:create, :destroy]
+  resources :shopping_list_favorites, only: [:create, :destroy]
+
   get 'mockups/recipes'
 end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -15,4 +15,36 @@ RSpec.describe ShoppingListItem, type: :model do
       it { should validate_presence_of(:shopping_list_id) }
     end
   end
+
+  describe 'self.by_recently_edited' do
+    it 'returns the most recently editied item first' do
+      item1 = create(:shopping_list_item)
+      item2 = create(:shopping_list_item)
+      item3 = create(:shopping_list_item)
+      item2.purchased = true
+      item2.save
+
+      ordered_items = ShoppingListItem.by_recently_edited
+
+      expect(ordered_items.first).to eq(item2)
+    end
+  end
+
+  describe '#complete!' do
+    it 'sets the "purchased" attribute to true and saves the item' do
+      item = create(:shopping_list_item, purchased: false)
+      item.complete!
+
+      expect(item.purchased).to eq(true)
+    end
+  end
+
+  describe '#uncomplete!' do
+    it 'sets the "purchased" attribute to false and saves the item' do
+      item = create(:shopping_list_item, purchased: true)
+      item.uncomplete!
+
+      expect(item.purchased).to eq(false)
+    end
+  end
 end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -12,4 +12,32 @@ RSpec.describe ShoppingList, type: :model do
       it { should validate_presence_of(:name) }
     end
   end
+
+  describe '.by_favorite' do
+    it 'returns results with the favorite first' do
+      favorite_list = create(:shopping_list, favorite: true)
+      regular_list = create(:shopping_list, favorite: false)
+      ordered_lists = ShoppingList.by_favorite
+
+      expect(ordered_lists.first).to eq(favorite_list)
+    end
+  end
+
+  describe '#favorite!' do
+    it 'sets the "favorite" attribute to true and saves the list' do
+      list = create(:shopping_list, favorite: false)
+      list.favorite!
+
+      expect(list.favorite).to eq(true)
+    end
+  end
+
+  describe '#unfavorite!' do
+    it 'sets the "favorite" attribute to false and saves the list' do
+      list = create(:shopping_list, favorite: true)
+      list.unfavorite!
+
+      expect(list.favorite).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Closes #43 

Before there was no way of knowing which lists were favorites and no way of changing this state.
<img width="342" alt="Screenshot 2019-08-10 12 21 23" src="https://user-images.githubusercontent.com/8680712/62824944-a70b3300-bb69-11e9-9a0e-d2e12f2256d7.png">

After, now we can see a yellow star next to the favorite list. There can only be 1 favorite at a time. On the index page, the lists are ordered with the favorite on top and then by alpha order.
<img width="336" alt="Screenshot 2019-08-11 18 34 43" src="https://user-images.githubusercontent.com/8680712/62840901-b8863500-bc66-11e9-9b89-ca47d9de0138.png">

