### PR TITLE
35 add recipe items to grocery

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Related Issues & PRs
+> Closes #X
+
+## Problems Solved
+>
+
+## Screenshots
+[screenshots here]
+
+## Things Learned
+>

--- a/app/controllers/shopping_list_item_builders_controller.rb
+++ b/app/controllers/shopping_list_item_builders_controller.rb
@@ -2,15 +2,21 @@
 
 class ShoppingListItemBuildersController < ApplicationController
   def create
+    recipe = Recipe.find(permitted_params[:recipe_id]) if permitted_params[:recipe_id]
+    meal_plan = MealPlan.find(permitted_params[:meal_plan_id]) if permitted_params[:meal_plan_id]
+
     builder = ShoppingListItemBuilder.new(
       shopping_list: ShoppingList.find(permitted_params[:shopping_list_id]),
       single_ingredient: Ingredient.where(id: permitted_params[:ingredient_id]),
-      meal_plan: MealPlan.find(permitted_params[:meal_plan_id]),
+      meal_plan: meal_plan,
+      recipe: recipe
     )
     builder.add_items_to_list
 
     flash[:success] = "#{ActionController::Base.helpers.pluralize(builder.ingredients.count, 'item')} added."
-    redirect_to builder.meal_plan
+
+    redirect_path = meal_plan.present? ? meal_plan : recipe
+    redirect_to redirect_path
   end
 
   private
@@ -18,6 +24,7 @@ class ShoppingListItemBuildersController < ApplicationController
   def permitted_params
     params.permit(:shopping_list_id,
                   :meal_plan_id,
+                  :recipe_id,
                   :ingredient_id)
   end
 end

--- a/app/models/shopping_list_item_builder.rb
+++ b/app/models/shopping_list_item_builder.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class ShoppingListItemBuilder
-  attr_reader :ingredients, :meal_plan
+  attr_reader :ingredients, :meal_plan, :recipe
 
-  def initialize(shopping_list:, single_ingredient: nil, meal_plan:)
+  def initialize(shopping_list:, single_ingredient: nil, meal_plan:, recipe:)
     @shopping_list = shopping_list
+    @single_ingredient = single_ingredient
     @meal_plan = meal_plan
-    @ingredients = single_ingredient.empty? ? meal_plan.ingredients : single_ingredient
+    @recipe = recipe
+    @ingredients = assign_ingredients
   end
 
   def add_ingredient_to_list(ingredient)
@@ -43,5 +45,15 @@ class ShoppingListItemBuilder
 
   def unassigned_aisle
     Aisle.unassigned(@shopping_list)
+  end
+
+  def assign_ingredients
+    if @single_ingredient.present?
+      @single_ingredient
+    elsif @meal_plan.present?
+      @meal_plan.ingredients
+    elsif @recipe.present?
+      @recipe.ingredients
+    end
   end
 end

--- a/app/views/recipes/_related_meal_plans.html.erb
+++ b/app/views/recipes/_related_meal_plans.html.erb
@@ -1,9 +1,7 @@
-<div class="col-sm-4">
-  <h5>Related Meal Plans</h5>
-  <ul>
-    <li><%= link_to '+ Add to a Meal Plan', '#' %></li>
-    <% recipe.meal_plans.order(start_date: :desc).limit(5).each do |plan| %>
-      <li><%= link_to "#{l plan.start_date, format: :month_as_text}", plan %></li>
-    <% end %>
-  </ul>
-</div>
+<h5>Related Meal Plans</h5>
+<ul>
+  <li><%= link_to '+ Add to a Meal Plan', '#' %></li>
+  <% recipe.meal_plans.order(start_date: :desc).limit(5).each do |plan| %>
+    <li><%= link_to "#{l plan.start_date, format: :month_as_text}", plan %></li>
+  <% end %>
+</ul>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -30,7 +30,17 @@
     </ul>
   </div>
 
-  <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
+  <div class="col-sm-4">
+    <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
+    <%= link_to '+ Add All Ingredients to Grocery List',
+                shopping_list_item_builders_path(
+                  shopping_list_id: ShoppingList.default(current_user).id,
+                  recipe_id: @recipe.id
+                ),
+                method: 'POST',
+                class: button_classes('info')
+    %>
+  </div>
 
   <div class="col-sm-4">
     <div class="image-container">

--- a/spec/models/shopping_list_item_builder_spec.rb
+++ b/spec/models/shopping_list_item_builder_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       builder = ShoppingListItemBuilder.new(
         shopping_list: shopping_list,
         single_ingredient: [],
-        meal_plan: meal_plan
+        meal_plan: meal_plan,
+        recipe: nil
       )
       builder.add_items_to_list
       expected_list_items = meal_plan.ingredients.map { |ingredient| "#{ingredient.measurement_unit} #{ingredient.name}" }
@@ -34,7 +35,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         builder = ShoppingListItemBuilder.new(
           shopping_list: shopping_list,
           single_ingredient: [],
-          meal_plan: meal_plan
+          meal_plan: meal_plan,
+          recipe: nil
         )
         builder.add_items_to_list
         item = shopping_list.items.last
@@ -49,7 +51,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         builder = ShoppingListItemBuilder.new(
           shopping_list: shopping_list,
           single_ingredient: [],
-          meal_plan: meal_plan
+          meal_plan: meal_plan,
+          recipe: nil
         )
         builder.add_items_to_list
         item = shopping_list.items.last
@@ -64,7 +67,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         builder = ShoppingListItemBuilder.new(
           shopping_list: shopping_list,
           single_ingredient: [],
-          meal_plan: meal_plan
+          meal_plan: meal_plan,
+          recipe: nil
         )
         builder.add_items_to_list
         item = shopping_list.items.last
@@ -90,7 +94,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           builder = ShoppingListItemBuilder.new(
             shopping_list: shopping_list,
             single_ingredient: [],
-            meal_plan: meal_plan
+            meal_plan: meal_plan,
+            recipe: nil
           )
           # add item for the first time
           builder.add_items_to_list
@@ -116,7 +121,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           builder = ShoppingListItemBuilder.new(
             shopping_list: shopping_list,
             single_ingredient: [],
-            meal_plan: meal_plan
+            meal_plan: meal_plan,
+            recipe: nil
           )
           # add item for the first time
           builder.add_items_to_list
@@ -140,7 +146,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           builder = ShoppingListItemBuilder.new(
             shopping_list: shopping_list,
             single_ingredient: [],
-            meal_plan: meal_plan
+            meal_plan: meal_plan,
+            recipe: nil
           )
           # add item for the first time
           builder.add_items_to_list
@@ -166,7 +173,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           builder = ShoppingListItemBuilder.new(
             shopping_list: shopping_list,
             single_ingredient: [],
-            meal_plan: meal_plan
+            meal_plan: meal_plan,
+            recipe: nil
           )
           # add item for the first time
           builder.add_items_to_list


### PR DESCRIPTION
## Related Issues & PRs
> Closes #35

## Problems Solved
> A user can now add all ingredients of a recipe to the grocery list directly from the recipe show page. This feature was currently not available. 

## Screenshots
<img width="1158" alt="Screenshot 2019-11-23 09 13 47" src="https://user-images.githubusercontent.com/8680712/69480925-b1c49d80-0dd1-11ea-8b7d-d17401e981d9.png">


## Things Learned
> I've made quite a mess for myself. The adding of ingredients to a list has a lot of checking for nils. This feels like something is wrong, but I don't know what it is. It feels like overkill to have individual guaranteed objects for each of the 3 ingredient sources (meal plan, recipe, individual ingredient). Maybe I need a guaranteed ingredient?
