### PR TITLE
Refactor shopping list item builder to need only shopping list id and ingredient ids

### DIFF
--- a/app/controllers/shopping_list_item_builders_controller.rb
+++ b/app/controllers/shopping_list_item_builders_controller.rb
@@ -2,29 +2,20 @@
 
 class ShoppingListItemBuildersController < ApplicationController
   def create
-    recipe = Recipe.find(permitted_params[:recipe_id]) if permitted_params[:recipe_id]
-    meal_plan = MealPlan.find(permitted_params[:meal_plan_id]) if permitted_params[:meal_plan_id]
-
     builder = ShoppingListItemBuilder.new(
-      shopping_list: ShoppingList.find(permitted_params[:shopping_list_id]),
-      single_ingredient: Ingredient.where(id: permitted_params[:ingredient_id]),
-      meal_plan: meal_plan,
-      recipe: recipe
+      shopping_list_id: permitted_params[:shopping_list_id],
+      ingredient_ids: permitted_params[:ingredient_ids]
     )
     builder.add_items_to_list
 
     flash[:success] = "#{ActionController::Base.helpers.pluralize(builder.ingredients.count, 'item')} added."
 
-    redirect_path = meal_plan.present? ? meal_plan : recipe
-    redirect_to redirect_path
+    redirect_back(fallback_location: root_path)
   end
 
   private
 
   def permitted_params
-    params.permit(:shopping_list_id,
-                  :meal_plan_id,
-                  :recipe_id,
-                  :ingredient_id)
+    params.permit(:shopping_list_id, ingredient_ids: [])
   end
 end

--- a/app/helpers/meal_plans_helper.rb
+++ b/app/helpers/meal_plans_helper.rb
@@ -4,4 +4,10 @@ module MealPlansHelper
   def display_recipes(meal_plan)
     meal_plan.recipes.map(&:title).join(', ')
   end
+
+  def meal_plan_ingredient_ids(ingredient_set)
+    # ingredient_set is a hash where the key is
+    # a recipe, and the values are ingredients
+    ingredient_set.values.flatten.pluck(:id)
+  end
 end

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -23,4 +23,8 @@ module RecipesHelper
 
     "<i class=\"#{Icon.clock}\", title=\"Heads Up! #{recipe.extra_work_note}\"></i>".html_safe
   end
+
+  def recipe_ingredient_ids(recipe)
+    recipe.ingredients.pluck(:id)
+  end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -99,6 +99,10 @@ class Ingredient < ApplicationRecord
     self.name = name.downcase
   end
 
+  def measurement_and_name
+    "#{measurement_unit} #{name}"
+  end
+
   # def to_shopping_list_item
   #   ShoppingListItem.new(
   #     quantity: self.quantity,

--- a/app/models/shopping_list_item_builder.rb
+++ b/app/models/shopping_list_item_builder.rb
@@ -1,59 +1,45 @@
 # frozen_string_literal: true
 
 class ShoppingListItemBuilder
-  attr_reader :ingredients, :meal_plan, :recipe
+  attr_reader :shopping_list, :ingredients
 
-  def initialize(shopping_list:, single_ingredient: nil, meal_plan:, recipe:)
-    @shopping_list = shopping_list
-    @single_ingredient = single_ingredient
-    @meal_plan = meal_plan
-    @recipe = recipe
-    @ingredients = assign_ingredients
-  end
-
-  def add_ingredient_to_list(ingredient)
-    item_name = "#{ingredient.measurement_unit} #{ingredient.name}"
-    item = @shopping_list.shopping_list_items.find_by(name: item_name)
-    incoming_quantity = ingredient.quantity
-
-    if item.nil?
-      ShoppingListItem.create!(
-        shopping_list_id: @shopping_list.id,
-        aisle_id: unassigned_aisle.id,
-        quantity: incoming_quantity,
-        name: item_name,
-        purchased: false
-      )
-    elsif item.purchased?
-      item.update!(
-        quantity: incoming_quantity,
-        purchased: false
-      )
-    else
-      item.quantity += incoming_quantity
-      item.save
-    end
+  def initialize(shopping_list_id:, ingredient_ids:)
+    @shopping_list = ShoppingList.find_by(id: shopping_list_id)
+    @ingredients = Ingredient.where(id: ingredient_ids)
   end
 
   def add_items_to_list
-    @ingredients.each do |ingredient|
+    self.ingredients.each do |ingredient|
       add_ingredient_to_list(ingredient)
     end
   end
 
   private
 
-  def unassigned_aisle
-    Aisle.unassigned(@shopping_list)
+  def add_ingredient_to_list(ingredient)
+    item_on_list = self.shopping_list.shopping_list_items.find_by(name: ingredient.measurement_and_name)
+    incoming_quantity = ingredient.quantity
+
+    if item_on_list.nil?
+      ShoppingListItem.create!(
+        shopping_list_id: shopping_list.id,
+        aisle_id: unassigned_aisle.id,
+        quantity: incoming_quantity,
+        name: ingredient.measurement_and_name,
+        purchased: false
+      )
+    elsif item_on_list.purchased?
+      item_on_list.update!(
+        quantity: incoming_quantity,
+        purchased: false
+      )
+    else
+      item_on_list.quantity += incoming_quantity
+      item_on_list.save
+    end
   end
 
-  def assign_ingredients
-    if @single_ingredient.present?
-      @single_ingredient
-    elsif @meal_plan.present?
-      @meal_plan.ingredients
-    elsif @recipe.present?
-      @recipe.ingredients
-    end
+  def unassigned_aisle
+    Aisle.unassigned(shopping_list)
   end
 end

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -27,7 +27,7 @@
     <%= link_to '+ Add All Ingredients to Grocery List',
                 shopping_list_item_builders_path(
                   shopping_list_id: ShoppingList.default(current_user).id,
-                  ingredient_ids: @ingredient_set.values.flatten.pluck(:id)
+                  ingredient_ids: meal_plan_ingredient_ids(@ingredient_set)
                 ),
                 method: 'POST',
                 class: button_classes('info')

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -27,7 +27,7 @@
     <%= link_to '+ Add All Ingredients to Grocery List',
                 shopping_list_item_builders_path(
                   shopping_list_id: ShoppingList.default(current_user).id,
-                  meal_plan_id: @meal_plan.id
+                  ingredient_ids: @ingredient_set.values.flatten.pluck(:id)
                 ),
                 method: 'POST',
                 class: button_classes('info')
@@ -50,8 +50,7 @@
         <%= link_to '',
                     shopping_list_item_builders_path(
                       shopping_list_id: ShoppingList.default(current_user).id,
-                      meal_plan_id: @meal_plan.id,
-                      ingredient_id: detail.id
+                      ingredient_ids: [detail.id]
                     ),
                     method: 'POST',
                     title: 'add to list',

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -35,7 +35,7 @@
     <%= link_to '+ Add All Ingredients to Grocery List',
                 shopping_list_item_builders_path(
                   shopping_list_id: ShoppingList.default(current_user).id,
-                  recipe_id: @recipe.id
+                  ingredient_ids: @recipe.ingredients.pluck(:id)
                 ),
                 method: 'POST',
                 class: button_classes('info')

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -35,7 +35,7 @@
     <%= link_to '+ Add All Ingredients to Grocery List',
                 shopping_list_item_builders_path(
                   shopping_list_id: ShoppingList.default(current_user).id,
-                  ingredient_ids: @recipe.ingredients.pluck(:id)
+                  ingredient_ids: recipe_ingredient_ids(@recipe)
                 ),
                 method: 'POST',
                 class: button_classes('info')

--- a/spec/models/shopping_list_item_builder_spec.rb
+++ b/spec/models/shopping_list_item_builder_spec.rb
@@ -4,40 +4,40 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
   describe '#add_items_to_list' do
     let(:shopping_list) { create(:shopping_list) }
     let(:meal_plan) { create(:meal_plan) }
-    let(:recipe1) { create(:recipe, :with_2_ingredients) }
-    let(:recipe2) { create(:recipe, :with_2_ingredients) }
-
-    it 'adds all ingredients as shopping_list_items on the given shopping_list' do
-      meal_plan.recipes << [recipe1, recipe2]
-      builder = ShoppingListItemBuilder.new(
-        shopping_list: shopping_list,
-        single_ingredient: [],
-        meal_plan: meal_plan,
-        recipe: nil
+    let(:recipe) { create(:recipe) }
+    let(:ingredient) { create(:ingredient, recipe: recipe, quantity: 1, measurement_unit: 'cup', name: 'rice') }
+    let(:ingredients) { create_list(:ingredient, 3) }
+    let(:ingredient_ids) { ingredient.id }
+    let(:builder) do
+      ShoppingListItemBuilder.new(
+        shopping_list_id: shopping_list.id,
+        ingredient_ids: ingredient_ids
       )
-      builder.add_items_to_list
-      expected_list_items = meal_plan.ingredients.map { |ingredient| "#{ingredient.measurement_unit} #{ingredient.name}" }
-      actual_list_items = shopping_list.shopping_list_items.map(&:name)
+    end
 
-      expect(expected_list_items).to eq(actual_list_items)
+    context 'when passed an array' do
+      let(:ingredient_ids) { ingredients.pluck(:id) }
+      it 'adds all ingredients as shopping_list_items on the given shopping_list' do
+        builder.add_items_to_list
+        expected_list_items = ingredients.map(&:measurement_and_name)
+        actual_list_items = shopping_list.shopping_list_items.map(&:name)
+
+        expect(expected_list_items).to eq(actual_list_items)
+      end
+    end
+
+    context 'when passed a single ingredient' do
+      it 'adds all ingredients as shopping_list_items on the given shopping_list' do
+        builder.add_items_to_list
+        expected_list_items = [ingredient].map(&:measurement_and_name)
+        actual_list_items = shopping_list.shopping_list_items.map(&:name)
+
+        expect(expected_list_items).to eq(actual_list_items)
+      end
     end
 
     context 'when an ingredient is new to the shopping list' do
-      let(:shopping_list) { create(:shopping_list) }
-      let(:meal_plan) { create(:meal_plan) }
-      let(:recipe) { create(:recipe) }
-      let(:ingredient) { create(:ingredient, recipe: recipe, quantity: 1, measurement_unit: 'cup', name: 'rice') }
-
       it 'the list item quantity equals the ingredient quantity' do
-        meal_plan.recipes << recipe
-        recipe.ingredients << ingredient
-
-        builder = ShoppingListItemBuilder.new(
-          shopping_list: shopping_list,
-          single_ingredient: [],
-          meal_plan: meal_plan,
-          recipe: nil
-        )
         builder.add_items_to_list
         item = shopping_list.items.last
 
@@ -45,15 +45,6 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       end
 
       it 'is not crossed off' do
-        meal_plan.recipes << recipe
-        recipe.ingredients << ingredient
-
-        builder = ShoppingListItemBuilder.new(
-          shopping_list: shopping_list,
-          single_ingredient: [],
-          meal_plan: meal_plan,
-          recipe: nil
-        )
         builder.add_items_to_list
         item = shopping_list.items.last
 
@@ -61,15 +52,6 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       end
 
       it 'assigns the list item to the "Unassigned" aisle' do
-        meal_plan.recipes << recipe
-        recipe.ingredients << ingredient
-
-        builder = ShoppingListItemBuilder.new(
-          shopping_list: shopping_list,
-          single_ingredient: [],
-          meal_plan: meal_plan,
-          recipe: nil
-        )
         builder.add_items_to_list
         item = shopping_list.items.last
 
@@ -79,24 +61,18 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
 
     context 'when an ingredient is already on the shopping list' do
       let(:user) { create(:user) }
-      let(:meal_plan) { create(:meal_plan, user: user) }
-      let(:recipe) { create(:recipe, user: user) }
-      let(:ingredient) { create(:ingredient, recipe: recipe, quantity: 1, measurement_unit: 'cup', name: 'rice') }
       let(:aisle) { create(:aisle, user: user, name: 'rice aisle') }
       let(:shopping_list) { create(:shopping_list, user: user) }
-      let(:shopping_list_item) { create(:shopping_list_item, shopping_list: shopping_list, name: 'cup rice') }
+      let(:shopping_list_item) do
+        create(
+          :shopping_list_item,
+          shopping_list: shopping_list,
+          name: ingredient.measurement_and_name
+        )
+      end
 
       context 'and has an aisle assigned' do
         it 'does not change that aisle assignment' do
-          meal_plan.recipes << recipe
-          recipe.ingredients << ingredient
-
-          builder = ShoppingListItemBuilder.new(
-            shopping_list: shopping_list,
-            single_ingredient: [],
-            meal_plan: meal_plan,
-            recipe: nil
-          )
           # add item for the first time
           builder.add_items_to_list
 
@@ -115,15 +91,6 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
 
       context 'and not marked as crossed-off' do
         it "the incoming ingredient's quantity is added to the list item's quantity" do
-          meal_plan.recipes << recipe
-          recipe.ingredients << ingredient
-
-          builder = ShoppingListItemBuilder.new(
-            shopping_list: shopping_list,
-            single_ingredient: [],
-            meal_plan: meal_plan,
-            recipe: nil
-          )
           # add item for the first time
           builder.add_items_to_list
 
@@ -140,15 +107,6 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
 
       context 'and marked as crossed-off' do
         it "the list item's quantity matches the incoming ingredient.quantity" do
-          meal_plan.recipes << recipe
-          recipe.ingredients << ingredient
-
-          builder = ShoppingListItemBuilder.new(
-            shopping_list: shopping_list,
-            single_ingredient: [],
-            meal_plan: meal_plan,
-            recipe: nil
-          )
           # add item for the first time
           builder.add_items_to_list
 
@@ -167,15 +125,6 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         end
 
         it 'is no longer crossed off' do
-          meal_plan.recipes << recipe
-          recipe.ingredients << ingredient
-
-          builder = ShoppingListItemBuilder.new(
-            shopping_list: shopping_list,
-            single_ingredient: [],
-            meal_plan: meal_plan,
-            recipe: nil
-          )
           # add item for the first time
           builder.add_items_to_list
 


### PR DESCRIPTION
## Related Issues & PRs
> Closes #141 

## Problems Solved
> Simplifies shopping list builder code to just have to know the shopping list id and ingredient ids

## Screenshots
![shopping-list-builder-refactor](https://user-images.githubusercontent.com/7945260/69497318-35998b00-0ea1-11ea-9f8a-19e22801ce96.gif)

## Things Learned
- Rails doesn't really like passing objects or relationships from the view to the controller, and prefers `ids`. 

 - As of rails 5, the syntax for redirecting back is `redirect_back`. More about that [here](https://medium.com/@hsdeekshith/redirect-to-back-is-deprecated-in-rails-5-what-to-use-instead-7ac8e970cd39).

## Misc Notes
- This change simplifies the tests a lot, and moving the logic to one `let` avoids having to change code in all the places when the logic changes. For example, I went back and forth between passing ids and objects, and before refactoring the tests, I had to change lots of places.

- There's some more refactoring I want to do, particularly making `ShoppingListItemBuilder` a 'service object' or some similar pattern. Currently if something breaks inside it, it just borks rather than returning a useful error message.
