### PR TITLE
29 add recipe to meal plan from index and show pages

### DIFF
--- a/app/controllers/meal_plan_recipes_controller.rb
+++ b/app/controllers/meal_plan_recipes_controller.rb
@@ -7,10 +7,10 @@ class MealPlanRecipesController < ApplicationController
     meal_plan_recipe = MealPlanRecipe.new({ meal_plan: meal_plan, recipe: recipe })
 
     if meal_plan_recipe.save
-      redirect_to recipes_url, notice: "#{recipe.title} added to #{meal_plan.start_date.to_s(:short)} meal plan"
+      redirect_back fallback_location: recipes_url, notice: "#{recipe.title} added to #{meal_plan.start_date.to_s(:short)} meal plan"
     else
       flash[:error] = "#{recipe.title} was already part of the #{meal_plan.start_date.to_s(:short)} meal plan."
-      redirect_to recipes_url
+      redirect_back fallback_location: recipes_url
     end
   end
 

--- a/app/controllers/meal_plan_recipes_controller.rb
+++ b/app/controllers/meal_plan_recipes_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class MealPlanRecipesController < ApplicationController
+  def create
+    meal_plan = MealPlan.find_by(id: params[:meal_plan_id])
+    recipe = Recipe.find_by(id: params[:recipe_id])
+    meal_plan_recipe = MealPlanRecipe.new({ meal_plan: meal_plan, recipe: recipe })
+
+    if meal_plan_recipe.save
+      redirect_to recipes_url, notice: "#{recipe.title} added to #{meal_plan.start_date.to_s(:short)} meal plan"
+    else
+      flash[:error] = "#{recipe.title} was already part of the #{meal_plan.start_date.to_s(:short)} meal plan."
+      redirect_to recipes_url
+    end
+  end
+
+  private
+
+  def meal_plan_params
+    params.require(:meal_plan).permit(:meal_plan_id, :recipe_id)
+  end
+end

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -4,9 +4,5 @@ class MealPlanRecipe < ApplicationRecord
   belongs_to :meal_plan
   belongs_to :recipe
 
-  validates :meal_plan_id,
-            :recipe_id,
-            presence: true
-
   validates :recipe_id, uniqueness: { scope: :meal_plan_id }
 end

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -3,4 +3,10 @@
 class MealPlanRecipe < ApplicationRecord
   belongs_to :meal_plan
   belongs_to :recipe
+
+  validates :meal_plan_id,
+            :recipe_id,
+            presence: true
+
+  validates :recipe_id, uniqueness: { scope: :meal_plan_id }
 end

--- a/app/views/recipes/_related_meal_plans.html.erb
+++ b/app/views/recipes/_related_meal_plans.html.erb
@@ -1,6 +1,8 @@
 <h5>Related Meal Plans</h5>
+<%= link_to '+ Add to Upcoming Plan',
+            meal_plan_recipes_path(recipe_id: recipe.id, meal_plan_id: MealPlan.upcoming(current_user)&.id),
+            method: :post if MealPlan.upcoming(current_user).present? %>
 <ul>
-  <li><%= link_to '+ Add to a Meal Plan', '#' %></li>
   <% recipe.meal_plans.order(start_date: :desc).limit(5).each do |plan| %>
     <li><%= link_to "#{l plan.start_date, format: :month_as_text}", plan %></li>
   <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -10,10 +10,8 @@
         <tr>
           <th colspan='2'>Title</th>
           <th>Servings</th>
-          <th>Ingredients</th>
-          <th>Meal Plans</th>
           <th>Last Prepared</th>
-          <th>Actions</th>
+          <th colspan="2">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -24,10 +22,13 @@
             </div></td>
             <td><%= link_to recipe.title, recipe %> <%= extra_work_flag(recipe) %> <%= status_flag(recipe) %></td>
             <td><%= recipe.servings %></td>
-            <td><%= recipe.ingredients.count %></td>
-            <td><%= recipe.meal_plans.count %></td>
             <td><%= recipe.last_prepared %></td>
             <td><%= link_to 'Edit', edit_recipe_path(recipe), class: button_classes('outline-info') %></td>
+            <td>
+              <%= link_to 'Add to Upcoming Plan',
+                          meal_plan_recipes_path(recipe_id: recipe.id, meal_plan_id: MealPlan.upcoming(current_user)&.id), method: :post,
+                          class: button_classes('outline-info') if MealPlan.upcoming(current_user).present? %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :recipes
   resources :experimental_recipes, only: [:index, :new, :create, :edit, :update, :destroy]
   resources :meal_plans
+  resources :meal_plan_recipes, only: [:create]
   resources :shopping_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
     resources :shopping_list_items, only: [:new, :create, :edit, :update, :destroy]
   end

--- a/spec/factories/meal_plan_recipes.rb
+++ b/spec/factories/meal_plan_recipes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :meal_plan_recipe do
+    meal_plan
+    recipe
+  end
+end

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe MealPlanRecipe, type: :model do
   end
 
   context 'validations' do
-    it { should validate_presence_of(:meal_plan_id) }
-    it { should validate_presence_of(:recipe_id) }
-    
+    it 'is valid' do
+      expect(meal_plan_recipe).to be_valid
+    end
+
+    # Must create instance of meal_plan_recipe for uniqueness test to work
+    let!(:meal_plan_recipe) { create(:meal_plan_recipe) }
     it { should validate_uniqueness_of(:recipe_id).scoped_to(:meal_plan_id) }
   end
 end

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe MealPlanRecipe, type: :model do
+  context 'associations' do
+    it { should belong_to(:meal_plan) }
+    it { should belong_to(:recipe) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:meal_plan_id) }
+    it { should validate_presence_of(:recipe_id) }
+    
+    it { should validate_uniqueness_of(:recipe_id).scoped_to(:meal_plan_id) }
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
> Closes #29

## Problems Solved
> The user now has the ability to add a recipe to the upcoming meal plan directly from the recipes `index` and `show` pages. This action also takes uniqueness into account. We don't let the user add the same recipe to a meal plan more than one time. After the transaction, the user is redirected back to the appropriate page instead of always going to the index, for example. 

## Screenshots
A new button on the recipes#index to add to the upcoming meal plan
<img width="932" alt="Screenshot 2019-11-24 10 52 13" src="https://user-images.githubusercontent.com/8680712/69498169-587c6d00-0eaa-11ea-9ea9-1b9741f2bf7a.png">

A new link on the recipe show page to add to the upcoming meal plan
<img width="1054" alt="Screenshot 2019-11-24 11 03 59" src="https://user-images.githubusercontent.com/8680712/69498175-67fbb600-0eaa-11ea-8d9c-cdc1eed364f8.png">

A successful addition to a meal plan shows a flash message on the page. 
<img width="1060" alt="Screenshot 2019-11-24 10 43 17" src="https://user-images.githubusercontent.com/8680712/69497910-844a2380-0ea7-11ea-8d38-a5730b621376.png">

If the user attempts to add the same recipe twice, they'll see this error. 
<img width="1067" alt="Screenshot 2019-11-24 10 43 37" src="https://user-images.githubusercontent.com/8680712/69497911-844a2380-0ea7-11ea-9e14-1f322e9217cf.png">


## Things Learned
### 1. ShouldaMatchers scoped uniqueness "bug"
I was set back by confusing foreign key error messages when I wrote tests for the uniqueness validations. The hard-learned lesson is that you have to create an instance of the `MealPlanRecipe` object _before_  running the shoulda test. For example:

```ruby
# note the use of "!" with the "let"
let!(:meal_plan_recipe) { create(:meal_plan_recipe) }
it { should validate_uniqueness_of(:recipe_id).scoped_to(:meal_plan_id) }
```
This is because your test case needs an existing instance to compare to the instance it is creating. You can't ask a single instance of an object if it is unique. https://github.com/thoughtbot/shoulda-matchers/issues/682#issuecomment-78124438

I posted this as an answer on stackoverflow https://stackoverflow.com/a/59019890/5009528

### 2.  Redirecting back to previous page
Since a user can add a recipe to a meal plan from both the `index` and `show` pages, we wanted to make sure they were redirected back to hose respective pages after clicking that button. I found a solution to that here: https://stackoverflow.com/a/2140063/5009528 which uses the `request.referer` browser storage. This will also be useful in @mikevallano 's  issue #142 where the redirect is conditional. 
