### PR TITLE
Order aisles

### DIFF
--- a/app/controllers/aisles_controller.rb
+++ b/app/controllers/aisles_controller.rb
@@ -44,6 +44,8 @@ class AislesController < ApplicationController
   end
 
   def aisle_params
-    params.require(:aisle).permit(:user_id, :name)
+    params.require(:aisle).permit(:user_id,
+                                  :order_number,
+                                  :name)
   end
 end

--- a/app/controllers/aisles_controller.rb
+++ b/app/controllers/aisles_controller.rb
@@ -4,7 +4,7 @@ class AislesController < ApplicationController
   before_action :set_aisle, only: %i[edit update destroy]
 
   def index
-    @aisles = current_user.aisles.by_name
+    @aisles = current_user.aisles.by_order_number
   end
 
   def new

--- a/app/models/aisle.rb
+++ b/app/models/aisle.rb
@@ -7,8 +7,10 @@ class Aisle < ApplicationRecord
   has_many :shopping_list_items, dependent: :destroy
 
   validates :name,
-            presence: true,
-            uniqueness: { scope: :user_id }
+            :order_number,
+            presence: true
+
+  validates :name, uniqueness: { scope: :user_id }
 
   def self.unassigned(list)
     list.user.aisles

--- a/app/models/aisle.rb
+++ b/app/models/aisle.rb
@@ -15,7 +15,7 @@ class Aisle < ApplicationRecord
   def self.unassigned(list)
     list.user.aisles
         .where('name ILIKE ?', 'unassigned')
-        .first_or_create(name: 'unassigned')
+        .first_or_create(name: 'unassigned', order_number: 0)
   end
 
   def self.by_order_number

--- a/app/models/aisle.rb
+++ b/app/models/aisle.rb
@@ -17,4 +17,8 @@ class Aisle < ApplicationRecord
         .where('name ILIKE ?', 'unassigned')
         .first_or_create(name: 'unassigned')
   end
+
+  def self.by_order_number
+    order(order_number: :asc)
+  end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,6 +5,10 @@ module Searchable
     order(Arel.sql('lower(name) ASC'))
   end
 
+  def by_id
+    order(:id)
+  end
+
   def search(terms)
     if terms.blank?
       all

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -20,6 +20,10 @@ class ShoppingListItem < ApplicationRecord
     order(updated_at: 'DESC')
   end
 
+  def self.by_aisle_order_number
+    includes(:aisle).order('aisles.order_number')
+  end
+
   # Set the item's purchased setting to true and save the item
   def complete!
     update!(purchased: true)

--- a/app/views/aisles/_form.html.erb
+++ b/app/views/aisles/_form.html.erb
@@ -1,18 +1,29 @@
 <%= form_for(aisle) do |form| %>
   <%= render 'shared/errors', object: aisle %>
 
-    <div class='field'>
-      <%= form.label :name %>
-      <%= form.text_field :name, autofocus: true, placeholder: 'Enter aisle name', class: 'form-control' %>
+  <div class='row'>
+    <div class='col-sm-10'>
+      <div class='field'>
+        <%= form.label :name %>
+        <%= form.text_field :name, autofocus: true, placeholder: 'Enter aisle name', class: 'form-control' %>
+      </div>
     </div>
 
-    <div class='field'>
-      <%#= form.label 'select list' %>
+    <div class='col-sm-2'>
+      <div class='field'>
+        <%= form.label :order_number %>
+        <%= form.text_field :order_number, class: 'form-control' %>
+      </div>
     </div>
+  </div>
 
-    <div class='field'>
-      <%#= form.label 'select vendor' %>
-    </div>
+  <div class='field'>
+    <%#= form.label 'select list' %>
+  </div>
 
-    <%= form.submit class: button_classes %>
+  <div class='field'>
+    <%#= form.label 'select vendor' %>
+  </div>
+
+  <%= form.submit class: button_classes %>
 <% end %>

--- a/app/views/aisles/index.html.erb
+++ b/app/views/aisles/index.html.erb
@@ -9,7 +9,7 @@
 
   <% @aisles.each do |aisle| %>
     <h3 class='index-item'>
-      <%= aisle.name %> <span style="font-size: 1rem;"></span>
+      <%= aisle.order_number %> | <%= aisle.name %> <span style="font-size: 1rem;"></span>
       <span class='index-item-actions right'>
         <%= link_to "", edit_aisle_path(aisle), class: Icon.edit %>
         <%= link_to "", aisle, method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: Icon.delete %>

--- a/app/views/shopping_list_items/_form.html.erb
+++ b/app/views/shopping_list_items/_form.html.erb
@@ -21,7 +21,7 @@
     <div class='col-8'>
       <div class='field'>
         <%= form.label :aisle_id %>
-        <%= form.collection_select :aisle_id, current_user.aisles, :id, :name, {prompt: '-- Select an Aisle --'}, class: 'form-control' %>
+        <%= form.collection_select :aisle_id, current_user.aisles.by_order_number, :id, :name, {}, class: 'form-control' %>
       </div>
     </div>
 

--- a/app/views/shopping_list_items/_form.html.erb
+++ b/app/views/shopping_list_items/_form.html.erb
@@ -21,7 +21,7 @@
     <div class='col-8'>
       <div class='field'>
         <%= form.label :aisle_id %>
-        <%= form.collection_select :aisle_id, current_user.aisles.by_name, :id, :name, {}, class: 'form-control' %>
+        <%= form.collection_select :aisle_id, current_user.aisles.by_id, :id, :name, {}, class: 'form-control' %>
       </div>
     </div>
 

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -11,7 +11,7 @@
 </article>
 
 <section id='active-items'>
-  <% @shopping_list.shopping_list_items.order(:aisle_id).includes(:aisle).not_purchased.group_by(&:aisle).each do |aisle, items| %>
+  <% @shopping_list.shopping_list_items.by_aisle_order_number.not_purchased.group_by(&:aisle).each do |aisle, items| %>
     <% if aisle %>
       <h4 class='aisle'><%= aisle.name %></h4>
       <% items.each do |item| %>

--- a/db/migrate/20191125193320_add_order_number_to_aisles.rb
+++ b/db/migrate/20191125193320_add_order_number_to_aisles.rb
@@ -1,0 +1,5 @@
+class AddOrderNumberToAisles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :aisles, :order_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_08_002856) do
+ActiveRecord::Schema.define(version: 2019_11_25_193320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_11_08_002856) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "order_number"
     t.index ["user_id"], name: "index_aisles_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,7 +50,11 @@ end
 aisle_names = ['Unassigned', 'produce: fruits', 'produce: greens', 'produce: peppers',
                'produce: vegetables', 'produce: potatoes & roots', 'bread & tortillas']
 
-Aisle.create!(aisle_names.map{ |name| {name: name, user: user} })
+order_number = 0
+aisle_names.each do |aisle_name|
+  Aisle.create!(name: aisle_name, user: user, order_number: order_number)
+  order_number += 10
+end
 
 # Shopping Lists
 ShoppingList.create!(name: 'grocery', main: true, user: user)

--- a/spec/factories/aisles.rb
+++ b/spec/factories/aisles.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :aisle do
     user_id { create(:user).id }
-    sequence(:name) { |n| "ingredient name #{n}" }
+    sequence(:name) { |n| "aisle name #{n}" }
+    sequence(:order_number) { |n| n }
   end
 end

--- a/spec/models/aisle_spec.rb
+++ b/spec/models/aisle_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe Aisle, type: :model do
       expect(retured_aisle.name).to eq('unassigned')
     end
   end
+
+  describe 'self.by_order_number' do
+    it 'orders by order_number, ascending' do
+      second_aisle = create(:aisle, order_number: 2)
+      first_aisle = create(:aisle, order_number: 1)
+
+      expect(Aisle.by_order_number.first).to eq(first_aisle)
+      expect(Aisle.by_order_number.second).to eq(second_aisle)
+    end
+  end
 end

--- a/spec/models/aisle_spec.rb
+++ b/spec/models/aisle_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Aisle, type: :model do
         expect(aisle).to be_valid
       end
 
+      it { should validate_presence_of(:order_number) }
       it { should validate_presence_of(:name) }
       it { should validate_uniqueness_of(:name).scoped_to(:user_id) }
     end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe ShoppingListItem, type: :model do
     end
   end
 
+  describe 'self.by_aisle_order_number' do
+    it "orders based on the associated aisle's order_number" do
+      first_aisle = create(:aisle, name: 'first aisle', order_number: 1)
+      second_aisle = create(:aisle, name: 'second aisle', order_number: 2)
+
+      list = create(:shopping_list, name: 'list')
+      second_item = create(:shopping_list_item, shopping_list_id: list.id, aisle_id: second_aisle.id)
+      first_item = create(:shopping_list_item, shopping_list_id: list.id, aisle_id: first_aisle.id)
+
+      expect(list.shopping_list_items.by_aisle_order_number.first).to eq(first_item)
+      expect(list.shopping_list_items.by_aisle_order_number.last).to eq(second_item)
+    end
+  end
+
   describe '#complete!' do
     it 'sets the "purchased" attribute to true and saves the item' do
       item = create(:shopping_list_item, purchased: false)


### PR DESCRIPTION
## Problems Solved
> The ordering of aisles got a little out of hand. We have a mix of strings and numbers and they don't sort well together. Ordering them by name didn't work and ordering them by anything else made the system brittle. When I added a new aisle, everything was thrown off in the dropdowns. Now we're ordering by a dedicated `order_number` field and tranquility has been restored to the world of aisles. 
> * "unassigned" is now restored as the default aisle on the form
> * the shopping_lists#show is now in order

## Screenshots
<img width="476" alt="Screenshot 2019-11-25 18 10 07" src="https://user-images.githubusercontent.com/8680712/69588634-e04b9f80-0fae-11ea-9921-48ff605e06ae.png">
<img width="498" alt="Screenshot 2019-11-25 18 10 17" src="https://user-images.githubusercontent.com/8680712/69588635-e04b9f80-0fae-11ea-9bd9-ac2b7fe5a4c1.png">


## Things Learned
> This took a lot of thinking about how I wanted to approach this problem. I think in the future, I'd like to be able to drag/drop aisles into order.
