### PR TITLE
Autopopulate search term in new item

### DIFF
--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -5,7 +5,7 @@ class ShoppingListItemsController < ApplicationController
   before_action :set_shopping_list_item, only: %i[edit update destroy]
 
   def new
-    @shopping_list_item = @shopping_list.items.new(quantity: 1)
+    @shopping_list_item = @shopping_list.items.new(quantity: 1, name: params[:search_term])
   end
 
   def create

--- a/app/views/shopping_list_items/new.html.erb
+++ b/app/views/shopping_list_items/new.html.erb
@@ -1,8 +1,9 @@
 <% content_for(:title, 'Add an Item') %>
 
-<%= link_to 'Cancel', shopping_lists_path, class: 'btn btn-outline-primary right' %>
-
-<h3><%= @shopping_list.name %></h3>
+<h3>
+  <%= link_to "", @shopping_list, class: Icon.back %>
+  <%= @shopping_list.name %>
+</h3>
 <h1>Add an Item</h1>
 
 <%= render 'form' %>

--- a/app/views/shopping_lists/search.html.erb
+++ b/app/views/shopping_lists/search.html.erb
@@ -1,5 +1,5 @@
 <h1>
-  <%= link_to "", new_shopping_list_shopping_list_item_path(@shopping_list), class: Icon.new %>
+  <%= link_to "", new_shopping_list_shopping_list_item_path(@shopping_list, search_term: params[:search]), class: Icon.new %>  
   <%= link_to "", @shopping_list, class: Icon.back %>
   Find an Item
 </h1>
@@ -24,7 +24,7 @@
   </section>
 <% else %>
   <p>Sorry, there are no results matching <strong>"<%= params[:search] %>"</strong></p>
-  <%= link_to 'Create New Item', new_shopping_list_shopping_list_item_path(@shopping_list), class: button_class('primary btn-block mt-3') %>
+  <%= link_to 'Create New Item', new_shopping_list_shopping_list_item_path(@shopping_list, search_term: params[:search]), class: button_class('primary btn-block mt-3') %>
 <% end %>
 
 <script type='text/javascript'>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -9,7 +9,7 @@
 <article class='index-item'>
   <%= form_tag(search_shopping_list_path(@shopping_list), method: 'get', id: 'search-form' ) do %>
     <div class="col-xs-12">
-      <%= text_field_tag :search, params[:search], placeholder: 'Find an item...', class: 'form-control form-control-sm' %>
+      <%= text_field_tag :search, params[:search], placeholder: 'Find or Add an item...', class: 'form-control form-control-sm' %>
     </div>
   <% end %>
 </article>


### PR DESCRIPTION
## Problems Solved
> When creating a new shopping list item, it was a pain to have typed a thing to search, not find it, and then have to type it again in order to create a new item. This stores that searched term and populates it in the form field. 

## Screenshots
![Kapture 2019-12-11 at 18 14 57](https://user-images.githubusercontent.com/8680712/70671647-5b18e980-1c42-11ea-8aae-1924ddeff9c1.gif)

## Things Learned
> Params are a lovely thing to pass around. 
