### PR TITLE
126 Add banner to top of site when env == development

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -31,6 +31,14 @@ a { color: $link-color; }
   a { color: $medium-gray; }
 }
 
+.environment-banner {
+  color: $white;
+  font-family: monospace;
+  font-size: 1.25em;
+  padding: .75em;
+  text-align: center;
+}
+
 
 // BOOTSTRAP OVERRIDES
 .card {

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -1,0 +1,22 @@
+module EnvironmentBannerHelper
+  def current_branch
+    if git_available?
+      `git rev-parse --abbrev-ref HEAD`.chomp
+    else
+      ENV.fetch("CURRENT_BRANCH", "--branch-not-found--")
+    end
+  end
+
+  def current_sha
+    if git_available?
+      `git log --oneline -1`
+    else
+      ENV.fetch("CURRENT_SHA", "--sha-not-found--")
+    end
+  end
+
+  def git_available?
+    to_dev_null = "> /dev/null 2>&1"
+    system("which git #{to_dev_null} && git rev-parse --git-dir #{to_dev_null}")
+  end
+end

--- a/app/views/layouts/_environment_banner.html.erb
+++ b/app/views/layouts/_environment_banner.html.erb
@@ -1,0 +1,5 @@
+<% unless Rails.env.production? %>
+  <div class='environment-banner bg-secondary'>
+    👍 <%= Rails.env.upcase %>: <%= "#{current_branch}" %> 👍
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,8 @@
   </head>
 
   <body>
+    <%= render "layouts/environment_banner" %>
+
     <%= render 'shared/navbar/main' %>
     <div class='container'>
       <%= render 'shared/flashes' %>


### PR DESCRIPTION
## Related Issues & PRs
> Closes #126

## Problems Solved
> Too many times, I have found myself refreshing the production page and wondering why my changes weren't showing up. This is frustrating and a silly waste of time. Now it is clear when I am looking at a page in my development environment. 

## Screenshots
<img width="798" alt="Screenshot 2019-12-23 13 07 02" src="https://user-images.githubusercontent.com/8680712/71375870-3ba88780-2585-11ea-9f3b-19273a96c084.png">


## Things Learned
> You can grab nifty git info from the command line using `Rails.env` and `ENV.fetch()`.
