### PR TITLE
Convert recipe titles to links

### DIFF
--- a/app/helpers/meal_plans_helper.rb
+++ b/app/helpers/meal_plans_helper.rb
@@ -2,7 +2,9 @@
 
 module MealPlansHelper
   def display_recipes(meal_plan)
-    meal_plan.recipes.map(&:title).join(', ')
+    raw(meal_plan.recipes.map do |recipe|
+      link_to recipe.title, recipe
+    end.join(', '))
   end
 
   def meal_plan_ingredient_ids(ingredient_set)

--- a/spec/helpers/meal_plans_helper_spec.rb
+++ b/spec/helpers/meal_plans_helper_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe MealPlansHelper, type: :helper do
   describe 'display_recipes' do
-    it 'displays all recipes titles in a concatenated list joined by commas' do
+    it 'displays all recipes titles as links in a concatenated list joined by commas' do
       meal_plan = create(:meal_plan)
       recipe1 = create(:recipe, title: 'RecipeTitle1')
       recipe2 = create(:recipe, title: 'RecipeTitle2')
       meal_plan.recipes << [recipe1, recipe2]
 
-      expect(display_recipes(meal_plan)).to eq('RecipeTitle1, RecipeTitle2')
+      expect(display_recipes(meal_plan)).to eq("<a href=\"/recipes/#{recipe1.id}\">RecipeTitle1</a>, <a href=\"/recipes/#{recipe2.id}\">RecipeTitle2</a>")
     end
   end
 end


### PR DESCRIPTION
## Problems Solved
> I found myself wanting to get to the recipe easily from this page but there were no links to do so. Now each recipe title is linked to the recipe show page. 

## Screenshots
Before: No links
<img width="533" alt="Screenshot 2020-01-08 20 00 48" src="https://user-images.githubusercontent.com/8680712/72031301-a201fb00-3251-11ea-99d2-418979ba7f94.png">

After: Totes links
<img width="713" alt="Screenshot 2020-01-08 20 00 35" src="https://user-images.githubusercontent.com/8680712/72031300-a201fb00-3251-11ea-9c4b-7cfad5defba0.png">

## Things Learned
> It sure was handy having the [`danebook` project](https://github.com/lortza/project_danebook/blob/master/app/helpers/likes_helper.rb#L3-L7) as reference when i needed to map over a bunch of items _and_ return a link.
```ruby
# the danebook code snippet

  def list_likes(likes)
    raw(likes.limit(3).map do |like|
      link_to like.user.name, user_timeline_path(like.user)
    end.join(", "))
  end
```

```ruby
# the code in this PR
def display_recipes(meal_plan)
  raw(meal_plan.recipes.map do |recipe|
    link_to recipe.title, recipe
  end.join(', '))
end
```
I should probably write a blog post about this so that I can find it again more easily and also help others to solve this problem.
