### PR TITLE
Replace link with dropdown

### DIFF
--- a/app/views/recipes/_add_to_meal_plan_dropdown.html.erb
+++ b/app/views/recipes/_add_to_meal_plan_dropdown.html.erb
@@ -1,18 +1,16 @@
 <%= form_for(meal_plan_recipe) do |form| %>
-  <% if available_meal_plans_dropdown(current_user, recipe).any? %>
-    <%= hidden_field_tag(:recipe_id, recipe.id) %>
-    <div class='row'>
-      <div class='col'>
-        <%= form.collection_select :meal_plan_id,
-                                   available_meal_plans_dropdown(current_user, recipe),
-                                   :id, :start_date, {},
-                                   class: 'form-control form-control-sm'
-        %>
-      </div>
+  <%= hidden_field_tag(:recipe_id, recipe.id) %>
+  <div class='row'>
+    <div class='col'>
+      <%= form.collection_select :meal_plan_id,
+                                 available_meal_plans_dropdown(current_user, recipe),
+                                 :id, :start_date, {},
+                                 class: 'form-control form-control-sm'
+      %>
+    </div>
 
-      <div class='col'>
-        <%= form.submit 'Add to Plan', class: button_classes('outline-info') %>
-      </div>
-    </div> <!-- row -->
-  <% end %>
+    <div class='col'>
+      <%= form.submit 'Add to Plan', class: button_classes('outline-info') %>
+    </div>
+  </div> <!-- row -->
 <% end %>

--- a/app/views/recipes/_related_meal_plans.html.erb
+++ b/app/views/recipes/_related_meal_plans.html.erb
@@ -1,7 +1,9 @@
 <h5>Related Meal Plans</h5>
-<%= link_to '+ Add to Upcoming Plan',
-            meal_plan_recipes_path(recipe_id: recipe.id, meal_plan_id: current_user.meal_plans.upcoming&.id),
-            method: :post if current_user.meal_plans.upcoming.present? %>
+<% if available_meal_plans_dropdown(current_user, recipe).any? %>
+  <small>Add to Upcoming Plans:</small>
+  <%= render 'add_to_meal_plan_dropdown', meal_plan_recipe: MealPlanRecipe.new, recipe: recipe %>
+<% end %>
+
 <ul>
   <% recipe.meal_plans.order(start_date: :desc).limit(5).each do |plan| %>
     <li><%= link_to "#{l plan.start_date, format: :month_as_text}", plan %></li>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -23,7 +23,10 @@
             <td><%= link_to recipe.title, recipe %> <%= extra_work_flag(recipe) %> <%= status_flag(recipe) %></td>
             <td><%= recipe.servings %></td>
             <td><%= recipe.last_prepared %></td>
-            <td><%= render 'add_to_meal_plan_dropdown', meal_plan_recipe: MealPlanRecipe.new, recipe: recipe %></td>
+            <td>
+              <% if available_meal_plans_dropdown(current_user, recipe).any? %>
+                <%= render 'add_to_meal_plan_dropdown', meal_plan_recipe: MealPlanRecipe.new, recipe: recipe %></td>
+              <% end %>
             <td><%= link_to 'Edit', edit_recipe_path(recipe), class: button_classes('outline-info') %></td>
           </tr>
         <% end %>


### PR DESCRIPTION
## Related Issues & PRs
> Related to #143

## Problems Solved
> Previously there was a link on the recipe show page to add a recipe to the next upcoming plan. This was the first step in making it easier to add recipes to meal plans. This PR is the next step: being able to add a recipe to  _any_ upcoming plan. 


## Screenshots
Before: link to add to upcoming meal plan
<img width="308" alt="Screenshot 2020-02-02 08 39 11" src="https://user-images.githubusercontent.com/8680712/73609082-236e5400-4598-11ea-9ec9-ca9b97265111.png">

After: replaced with dropdown to add recipe to any future meal plan
<img width="314" alt="Screenshot 2020-02-02 08 39 25" src="https://user-images.githubusercontent.com/8680712/73609083-2406ea80-4598-11ea-8e4a-9f6f329e5fe1.png">


## Things Learned
> Having a well-designed partial that I could reuse make this task unbelievably easy. Unfortunately, i had to pull the "should i display this dropdown?" logic out of the partial and put it in 2 places. I wonder if there is a tidier way to do this.
