### PR TITLE
Add duping method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/BlockLength:
     - 'spec/factories/**/*'
     - 'lib/tasks/*'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   Exclude:
   - !ruby/regexp /.*_spec\.rb$/

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem 'binding_of_caller'       # goes with better_errors
   gem 'bullet'                  # detects n+1 queries
   gem 'byebug', platforms: %i[mri mingw x64_mingw] # Call 'byebug' anywhere in the code to get a debugger console
+  gem 'factory_bot_rails'       # factory support for rspec
   gem 'pry-rails'               # helps with pry
   gem 'reek'                    # https://github.com/troessner/reek/blob/master/docs/Code-Smells.md
 end
@@ -51,7 +52,6 @@ group :development do
 end
 
 group :test do
-  gem 'factory_bot_rails'       # factory support for rspec
   gem 'launchy'                 # open browser with save_and_open_page
   gem 'shoulda-matchers'        # library for easier testing syntax
   gem 'webdrivers'              # to help with testing

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -35,7 +35,6 @@ class Recipe < ApplicationRecord
   validates :cook_time, numericality: { other_than: 0 }, if: -> { reheat_time&.zero? && prep_time&.zero? }
   validates :reheat_time, numericality: { other_than: 0 }, if: -> { prep_time&.zero? && cook_time&.zero? }
 
-
   def self.for_prep_date(date)
     # WIP
     # Recipe.joins(:preparations).where(preparations: {date: date})
@@ -77,5 +76,13 @@ class Recipe < ApplicationRecord
 
   def extra_work_required?
     extra_work_note.present?
+  end
+
+  def dupe_for_user(user)
+    original_ingredients = ingredients
+    copied_recipe = dup
+    copied_recipe.update(user_id: user.id)
+    copied_recipe.ingredients << original_ingredients
+    copied_recipe.save
   end
 end


### PR DESCRIPTION
## Related Issues & PRs
> Related to #206 

## Problems Solved
> I wanted to figure out a way to safely dupe my recipes for my mom to see. Instead of going rogue and doing this on the console, i wrote a method  that i'll be able to use to do this. I took this approach because duping incorrectly would cause me sadness in my production data. I wrote tests to make sure the method does what i expect it to do (and nothing more).

## Things Learned
> `dup`, `clone`, and `deep_dup` all behave a little differently. There are gems to handle this, but since i'm not doing this extensively, i just wrote a little method to handle it. 

## Risk
> Low. This is an additive change that is not being called anywhere yet. 
