### PR TITLE
70 choose list for recipe and meal plan ingredients

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Related Issues & PRs
-> Closes #X
+Closes #X
 
 ## Problems Solved
 >

--- a/app/controllers/shopping_list_item_builders_controller.rb
+++ b/app/controllers/shopping_list_item_builders_controller.rb
@@ -4,7 +4,8 @@ class ShoppingListItemBuildersController < ApplicationController
   def create
     builder = ShoppingListItemBuilder.new(
       shopping_list_id: permitted_params[:shopping_list_id],
-      ingredient_ids: permitted_params[:ingredient_ids]
+      # ingredient_ids: permitted_params[:ingredient_ids]
+      ingredient_ids: permitted_params[:ingredientids].split(' ').map(&:to_i)
     )
     builder.add_items_to_list
 
@@ -16,6 +17,6 @@ class ShoppingListItemBuildersController < ApplicationController
   private
 
   def permitted_params
-    params.permit(:shopping_list_id, ingredient_ids: [])
+    params.permit(:shopping_list_id, :ingredientids, ingredient_ids: [])
   end
 end

--- a/app/controllers/shopping_list_item_builders_controller.rb
+++ b/app/controllers/shopping_list_item_builders_controller.rb
@@ -4,12 +4,13 @@ class ShoppingListItemBuildersController < ApplicationController
   def create
     builder = ShoppingListItemBuilder.new(
       shopping_list_id: permitted_params[:shopping_list_id],
-      # ingredient_ids: permitted_params[:ingredient_ids]
-      ingredient_ids: permitted_params[:ingredientids].split(' ').map(&:to_i)
+      ingredient_ids: permitted_params[:ingredient_ids].split(' ').map(&:to_i)
     )
     builder.add_items_to_list
 
-    flash[:success] = "#{ActionController::Base.helpers.pluralize(builder.ingredients.count, 'item')} added."
+    list_name = builder.shopping_list.name
+    pluralized_ingredients = ActionController::Base.helpers.pluralize(builder.ingredients.count, 'item')
+    flash[:success] = "#{pluralized_ingredients} added to #{list_name.titleize} List."
 
     redirect_back(fallback_location: root_path)
   end
@@ -17,6 +18,6 @@ class ShoppingListItemBuildersController < ApplicationController
   private
 
   def permitted_params
-    params.permit(:shopping_list_id, :ingredientids, ingredient_ids: [])
+    params.permit(:shopping_list_id, :ingredient_ids)
   end
 end

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -24,14 +24,8 @@
       <li><%= link_to recipe.title, recipe_path(recipe) %>  <%= extra_work_flag(recipe) %> (<%= recipe.servings %> servings)</li>
       <% end %>
     </ol>
-    <%= link_to '+ Add All Ingredients to Grocery List',
-                shopping_list_item_builders_path(
-                  shopping_list_id: current_user.shopping_lists.default&.id,
-                  ingredient_ids: meal_plan_ingredient_ids(@ingredient_set)
-                ),
-                method: 'POST',
-                class: button_classes('info')
-    %>
+
+    <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: meal_plan_ingredient_ids(@ingredient_set) } %>
   </section>
 </div><!-- row -->
 

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -29,6 +29,7 @@
   </section>
 </div><!-- row -->
 
+<hr>
 <button id='button__ingredients-toggle' class='btn btn-sm btn-outline-secondary right opened'>Collapse All</button>
 <h2>Ingredient Breakdown</h2>
 <section id='section__ingredient-breakdown' class='row ingredient-breakdown'>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -32,13 +32,13 @@
 
   <div class="col-sm-4">
     <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
-    <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
   </div>
 
   <div class="col-sm-4">
-    <div class="image-container">
+    <div class="image-container mb-3">
       <%= image_tag @recipe.image_url, {class: 'image'} %>
     </div>
+    <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
   </div>
 </div><!-- row -->
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -32,14 +32,7 @@
 
   <div class="col-sm-4">
     <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
-    <%= link_to '+ Add All Ingredients to Grocery List',
-                shopping_list_item_builders_path(
-                  shopping_list_id: current_user.shopping_lists.default.id,
-                  ingredient_ids: recipe_ingredient_ids(@recipe)
-                ),
-                method: 'POST',
-                class: button_classes('info')
-    %>
+    <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
   </div>
 
   <div class="col-sm-4">

--- a/app/views/shared/_add_to_shopping_list_dropdown.html.erb
+++ b/app/views/shared/_add_to_shopping_list_dropdown.html.erb
@@ -1,0 +1,8 @@
+<%= link_to '+ Add All Ingredients to Grocery List',
+            shopping_list_item_builders_path(
+              shopping_list_id: current_user.shopping_lists.default&.id,
+              ingredient_ids: ingredient_ids
+            ),
+            method: 'POST',
+            class: button_classes('info')
+%>

--- a/app/views/shared/_add_to_shopping_list_dropdown.html.erb
+++ b/app/views/shared/_add_to_shopping_list_dropdown.html.erb
@@ -1,13 +1,4 @@
-<%#= link_to '+ Add All Ingredients to Grocery List',
-            shopping_list_item_builders_path(
-              shopping_list_id: current_user.shopping_lists.default&.id,
-              ingredient_ids: ingredient_ids
-            ),
-            method: 'POST',
-            class: button_classes('info')
-%>
-
-<small>Add All Ingredients to Shopping List:</small>
+<h5>Add All Ingredients to Shopping List:</h5>
 <%= form_tag(shopping_list_item_builders_path, method: 'post', id: 'add-to-list-form' ) do %>
   <div class='row'>
     <div class='col-10'>

--- a/app/views/shared/_add_to_shopping_list_dropdown.html.erb
+++ b/app/views/shared/_add_to_shopping_list_dropdown.html.erb
@@ -1,4 +1,4 @@
-<%= link_to '+ Add All Ingredients to Grocery List',
+<%#= link_to '+ Add All Ingredients to Grocery List',
             shopping_list_item_builders_path(
               shopping_list_id: current_user.shopping_lists.default&.id,
               ingredient_ids: ingredient_ids
@@ -6,3 +6,20 @@
             method: 'POST',
             class: button_classes('info')
 %>
+
+<small>Add All Ingredients to Shopping List:</small>
+<%= form_tag(shopping_list_item_builders_path, method: 'post', id: 'add-to-list-form' ) do %>
+  <div class='row'>
+    <div class='col-10'>
+      <%= hidden_field_tag :ingredientids, ingredient_ids %>
+      <%= select_tag :shopping_list_id,
+                     options_from_collection_for_select(current_user.shopping_lists.by_favorite, :id, :name),
+                     class: 'form-control'
+      %>
+    </div>
+
+    <div class='col-2'>
+      <%= submit_tag 'Add', class: 'btn btn-outline-info' %>
+    </div>
+  </div> <!-- row -->
+<% end %>

--- a/app/views/shared/_add_to_shopping_list_dropdown.html.erb
+++ b/app/views/shared/_add_to_shopping_list_dropdown.html.erb
@@ -11,7 +11,7 @@
 <%= form_tag(shopping_list_item_builders_path, method: 'post', id: 'add-to-list-form' ) do %>
   <div class='row'>
     <div class='col-10'>
-      <%= hidden_field_tag :ingredientids, ingredient_ids %>
+      <%= hidden_field_tag :ingredient_ids, ingredient_ids %>
       <%= select_tag :shopping_list_id,
                      options_from_collection_for_select(current_user.shopping_lists.by_favorite, :id, :name),
                      class: 'form-control'

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -9,6 +9,7 @@
       <h3 class='index-item'>
         <%= toggle_favorite(shopping_list) %>
         <%= link_to shopping_list.name, shopping_list_path(shopping_list) %>
+        (<%= shopping_list.items.not_purchased.length %>)
         <%  if shopping_list.deletable? %>
           <span class='index-item-actions right'>
             <%= link_to "", edit_shopping_list_path(shopping_list), class: Icon.edit %>

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -38,4 +38,24 @@ RSpec.describe RecipesHelper, type: :helper do
       expect(helper.status_flag(recipe)).to eq('')
     end
   end
+
+  describe 'recipe_ingredient_ids' do
+    it 'returns an array of ingredient ids from this recipe' do
+      recipe = create(:recipe, :with_2_ingredients)
+
+      expect(helper.recipe_ingredient_ids(recipe)).to be_a(Array)
+      expect(helper.recipe_ingredient_ids(recipe).length).to eq(2)
+    end
+
+    it "returns only ids for this recipe's ingredients" do
+      recipe1 = create(:recipe, :with_2_ingredients)
+      recipe2 = create(:recipe, :with_2_ingredients)
+
+      recipe1_results = recipe1.ingredients.pluck(:id)
+      expect(helper.recipe_ingredient_ids(recipe1)).to eq(recipe1_results)
+
+      recipe2_results = recipe2.ingredients.pluck(:id)
+      expect(helper.recipe_ingredient_ids(recipe1)).to_not eq(recipe2_results)
+    end
+  end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #70

## Problems Solved
> Allows me to choose which shopping list I want to add ingredients to. Defaults to my "favorite" list, which is my Grocery list.

## Screenshots
### Meal Plan show
Before
<img width="800" alt="Screenshot 2020-02-29 13 27 09" src="https://user-images.githubusercontent.com/8680712/75613807-7257cc80-5af7-11ea-8dd8-b87b9be61ffa.png">

After
<img width="800" alt="Screenshot 2020-02-29 13 26 55" src="https://user-images.githubusercontent.com/8680712/75613816-7be13480-5af7-11ea-85f7-ba091b3756b0.png">


### Recipe show
Before
<img width="800" alt="Screenshot 2020-02-29 13 27 18" src="https://user-images.githubusercontent.com/8680712/75613831-8996ba00-5af7-11ea-8533-6df61656691d.png">

After
<img width="800" alt="Screenshot 2020-02-29 13 27 33" src="https://user-images.githubusercontent.com/8680712/75613834-8dc2d780-5af7-11ea-873f-90b5cd9cf85b.png">


## Things Learned
The rails `form_tag` helper method called `hidden_field_tag` does not handle arrays of `id`s well. It converts them to a space-separated string. I posted [my solution on stackoverflow](https://stackoverflow.com/a/60468228/5009528). In a nutshell though, I fix the array in the controller:

The controller:
```ruby
ids_i_need = permitted_params[:ingredient_ids].split(' ').map(&:to_i)

def permitted_params
  params.permit(:shopping_list_id, :ingredient_ids)
end
```

The view:
```html
<%= form_tag(shopping_list_item_builders_path, method: 'post', id: 'add-to-list-form' ) do %>
      <%= hidden_field_tag :ingredient_ids, ingredient_ids %>
      <%= submit_tag 'Add', class: 'btn btn-outline-info' %>
<% end %>
```
