### PR TITLE
Enable markdown in instructions with redcarpet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.3'
-
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'coffee-rails'              # Use CoffeeScript for .coffee assets and views
 gem 'devise'                    # User authentication
@@ -15,6 +14,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'            # Use Puma as the app server
 gem 'rack', '>= 2.0.6'          # Upgrade for security update
 gem 'rails', '~> 6.0.2'         # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'redcarpet', github: 'vmg/redcarpet' # markdown
 gem 'sass-rails', '~> 6.0'      # Use SCSS for stylesheets
 gem 'uglifier', '>= 1.3.0'      # Use Uglifier as compressor for JavaScript assets
 gem 'will_paginate', '~> 3.3.0' # pagination. Styles: http://mislav.github.io/will_paginate/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GIT
   specs:
     rspec-support (3.9.0.pre)
 
+GIT
+  remote: https://github.com/vmg/redcarpet.git
+  revision: 6270d6b4ab6b46ee6bb57a6c0e4b2377c01780ae
+  specs:
+    redcarpet (3.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -433,6 +439,7 @@ DEPENDENCIES
   rack (>= 2.0.6)
   rails (~> 6.0.2)
   rails-erd
+  redcarpet!
   reek
   rspec-core!
   rspec-expectations!

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,4 +52,26 @@ module ApplicationHelper
 
     link_to "#{list.name.titleize}: #{item_count}", shopping_list_path(list), class: 'nav-link'
   end
+
+  class Renderer < Redcarpet::Render::HTML
+  end
+
+  def markdown(text)
+    redcarpet_options = {
+      autolink: true,
+      disable_indented_code_blocks: false,
+      fenced_code_blocks: true,
+      highlight: true,
+      lax_html_blocks: true,
+      lax_spacing: true,
+      no_intra_emphasis: true,
+      strikethrough: true,
+      superscript: true,
+      tables: true,
+    }
+
+    renderer = Renderer.new
+    markdown_to_html = Redcarpet::Markdown.new(renderer, redcarpet_options)
+    markdown_to_html.render(text).html_safe
+  end
 end

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -84,19 +84,22 @@
     <div class="tab-content" id="myTabContent">
       <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
         <ol>
-          <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+          <%#= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+          <%= markdown(@recipe.instructions) %>
         </ol>
       </div>
 
       <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
         <ol>
-          <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+          <%#= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+          <%= markdown(@recipe.prep_day_instructions) %>
         </ol>
       </div>
 
       <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
         <ol>
-          <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
+          <%#= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
+          <%= markdown(@recipe.reheat_instructions) %>
         </ol>
       </div>
     </div><!-- tab-content -->


### PR DESCRIPTION
## Related Issues & PRs
Closes #212

## Things Learned
> I did this work and was able to use markdown in the instructions fields, but i didn't like it for this particular application. Right now it is easier for me to let the existing setup automatically number the instruction steps. With markdown, i'd have to number them myself. Given how rarely i need to do anything else that markdown offers, i think i'll just stick to the current setup.
