### PR TITLE
Order recipes by last_prepared

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -8,7 +8,9 @@ class RecipesController < ApplicationController
     search_term = params[:search]
     recipes = search_term.present? ? user_recipes.search(field: 'title', terms: search_term) : user_recipes.active
 
-    @recipes = recipes.includes(:meal_plans, :meal_plan_recipes).by_last_prepared.paginate(page: params[:page], per_page: 30)
+    @recipes = recipes.includes(:meal_plans, :meal_plan_recipes)
+                      .by_last_prepared
+                      .paginate(page: params[:page], per_page: 30)
   end
 
   def show

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -8,7 +8,7 @@ class RecipesController < ApplicationController
     search_term = params[:search]
     recipes = search_term.present? ? user_recipes.search(field: 'title', terms: search_term) : user_recipes.active
 
-    @recipes = recipes.includes(:meal_plans).by_title.paginate(page: params[:page], per_page: 30)
+    @recipes = recipes.includes(:meal_plans, :meal_plan_recipes).by_last_prepared.paginate(page: params[:page], per_page: 30)
   end
 
   def show

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -42,6 +42,10 @@ class Recipe < ApplicationRecord
     # Recipe.joins(:preparations).where(preparations: {date: date})
   end
 
+  def self.by_last_prepared
+    order('meal_plans.start_date asc')
+  end
+
   def self.active
     where(archived: false)
   end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe Recipe, type: :model do
     end
   end
 
+  describe 'self.by_last_prepared' do
+    it 'puts recipes that have not been made in a while on top' do
+      recent_recipe = create(:recipe)
+      recent_meal_plan = create(:meal_plan, recipes: [recent_recipe], start_date: '2020-06-15')
+      old_recipe = create(:recipe)
+      old_meal_plan = create(:meal_plan, recipes: [old_recipe], start_date: '2018-06-15')
+
+      ordered_recipes = Recipe.includes(:meal_plans, :meal_plan_recipes).by_last_prepared
+
+      expect(ordered_recipes.first).to eq(old_recipe)
+      expect(ordered_recipes.last).to eq(recent_recipe)
+    end
+  end
+
   describe '#last_prepared' do
     let(:meal_plan_today) { create(:meal_plan, start_date: Time.zone.today) }
     let(:meal_plan_yesterday) { create(:meal_plan, start_date: Time.zone.yesterday) }


### PR DESCRIPTION
## Related Issues & PRs
Closes #218

## Problems Solved
Sorting recipes alphabetically has not been particularly useful since I just search for the recipes i am looking for. I'm trying an experiment where I put recipes that I have not made in a while at the top of the list. This way I don't have to do as much digging while doing meal planning. I don't know if I will end up liking this feature. 🤷‍♀ We'll see!


## Things Learned
My specs didn't pass until i did all of the proper "includes" like: 
```ruby
ordered_recipes = Recipe.includes(:meal_plans, :meal_plan_recipes).by_last_prepared
```
