### PR TITLE
Allow non-users to view recipe show page

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class RecipesController < ApplicationController
+  before_action :authenticate_user!, except: :show
   before_action :set_recipe, only: %i[show edit update destroy copy_for_user]
 
   def index

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -34,7 +34,9 @@
       </div> <!-- col-6 -->
 
       <div class='col-6'>
-        <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
+        <% if current_user.present? %>
+          <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
+        <% end %>
       </div> <!-- col-6 -->
     </div> <!-- row -->
 
@@ -65,9 +67,11 @@
     <div class='image-container mb-3'>
       <%= image_tag @recipe.image_url, {class: 'image'} %>
     </div>
-    <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
-    <%= render partial: 'copy_for_user_form', locals: { recipe: @recipe } %>
-    <%= render partial: 'related_recipes', locals: {recipe: @recipe} %>
+    <% if current_user.present? %>
+      <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
+      <%= render partial: 'copy_for_user_form', locals: { recipe: @recipe } %>
+      <%= render partial: 'related_recipes', locals: {recipe: @recipe} %>
+    <% end %>
   </div>
 </div> <!-- row -->
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -11,7 +11,9 @@
     </p>
   </div>
   <div class="col-1">
-    <div class="right"><%= link_to 'Edit', edit_recipe_path(@recipe), class: button_classes %></div>
+    <% if current_user.present? %>
+      <div class="right"><%= link_to 'Edit', edit_recipe_path(@recipe), class: button_classes %></div>
+    <% end %>
   </div>
 </div><!-- row -->
 


### PR DESCRIPTION
## Related Issues & PRs
Relates to #205

## Problems Solved
* Users don't have to have an account to see recipe show page

## Screenshots
A signed-in user sees this:
<img width="1107" alt="Screenshot 2020-03-21 12 01 07" src="https://user-images.githubusercontent.com/8680712/77231893-bd4f8780-6b6b-11ea-8cac-ea2deeb00cef.png">

An unauthenticated user sees this:
<img width="1082" alt="Screenshot 2020-03-21 12 05 10" src="https://user-images.githubusercontent.com/8680712/77231975-3f3fb080-6b6c-11ea-945b-fd0024066faa.png">

## Things Learned
* It is very easy to knock out this single authorization feature. I chose to do just this one thing right now because this is the most urgent feature I need. I will continue to work through the complete `pundit` setup for #205 in a subsequent PR.
