### PR TITLE
Make recipe show more mobile-friendly

### DIFF
--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -31,8 +31,7 @@
 }
 
 .image-container {
-  height: 200px;
-  max-width: 300px;
+  height: auto;
   overflow: hidden;
   width: 100%;
   .image { width: 100%; }

--- a/app/helpers/ingredients_helper.rb
+++ b/app/helpers/ingredients_helper.rb
@@ -2,11 +2,17 @@
 
 module IngredientsHelper
   def ingredient_display(ingredient)
-    [
+    display_name = [
       qty_display(ingredient),
       ingredient.measurement_unit,
       ingredient.name,
     ].join(' ')
+
+    if ingredient.preparation_style.present?
+      "#{display_name}: #{ingredient.preparation_style}"
+    else
+      display_name
+    end
   end
 
   def detail_display(detail)

--- a/app/views/recipes/_related_recipes.html.erb
+++ b/app/views/recipes/_related_recipes.html.erb
@@ -1,8 +1,10 @@
-<h5 class='mt-3'>Related Recipes</h5>
-<%= form_tag(recipes_path, :method => "get", id: 'search-form', class: 'form-inline' ) do %>
-  <%= text_field_tag :search, params[:search], placeholder: "Add a Related Recipe", class: 'form-control form-control-sm mr-3 w-75' %>
-  <i class="fas fa-search" aria-hidden="true"></i>
-<% end %>
-<ul>
-  <li><%= link_to 'TBD Recipe', '#' %></li>
-</ul>
+<template class='.d-sm-none .d-md-block'>
+  <h5 class='mt-3'>Related Recipes</h5>
+  <%= form_tag(recipes_path, :method => "get", id: 'search-form', class: 'form-inline' ) do %>
+    <%= text_field_tag :search, params[:search], placeholder: "Add a Related Recipe", class: 'form-control form-control-sm mr-3 w-75' %>
+    <i class="fas fa-search" aria-hidden="true"></i>
+  <% end %>
+  <ul>
+    <li><%= link_to 'TBD Recipe', '#' %></li>
+  </ul>
+</template>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -18,9 +18,9 @@
 </div><!-- row -->
 
 <div class='row'>
-  <div class='col-8'>
+  <div class='col-md-8 col-sm-12'>
     <div class='row'>
-      <div class='col-6'>
+      <div class='col-md-6 col-sm-12'>
         <h5>Stats</h5>
         <ul>
           <li>Servings: <%= @recipe.servings %></li>
@@ -35,7 +35,7 @@
         </ul>
       </div> <!-- col-6 -->
 
-      <div class='col-6'>
+      <div class='col-md-6 col-sm-12'>
         <% if current_user.present? %>
           <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
         <% end %>
@@ -49,25 +49,18 @@
         <h3>Ingredients</h3>
         <ul>
           <% @recipe.ingredients.by_id.each do |ingredient| %>
-          <li>
-            <div class="row">
-              <div class="col-sm">
-                <%= ingredient_display(ingredient) %>
-              </div>
-              <div class="col-sm">
-                <%= ingredient.preparation_style %>
-              </div>
-            </div> <!-- row -->
-          </li>
+            <li><%= ingredient_display(ingredient) %></li>
           <% end %>
         </ul>
       </div> <!-- col-12 -->
     </div> <!-- row -->
   </div> <!-- col-8 -->
 
-  <div class='col-4'>
+  <div class='col-md-4 col-sm-12'>
     <div class='image-container mb-3'>
-      <%= image_tag @recipe.image_url, {class: 'image'} %>
+      <%#= image_tag @recipe.image_url, { class: 'image' } %>
+      <%= image_tag guaranteed_image(@recipe), { class: 'image' } %>
+
     </div>
     <% if current_user.present? %>
       <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>

--- a/app/views/shared/_add_to_shopping_list_dropdown.html.erb
+++ b/app/views/shared/_add_to_shopping_list_dropdown.html.erb
@@ -1,16 +1,20 @@
 <h5>Add Ingredients to List:</h5>
 <%= form_tag(shopping_list_item_builders_path, method: 'post', id: 'add-to-list-form' ) do %>
-  <div class='row'>
-    <div class='col-10'>
-      <%= hidden_field_tag :ingredient_ids, ingredient_ids %>
+
+  <div class="form-row align-items-center">
+    <%= hidden_field_tag :ingredient_ids, ingredient_ids %>
+
+    <!-- <div class="col-md-8 col-sm-12"> -->
+    <div class="col-9">
+      <label class="sr-only" for="inlineFormInput">Shopping List</label>
       <%= select_tag :shopping_list_id,
                      options_from_collection_for_select(current_user.shopping_lists.by_favorite, :id, :name),
-                     class: 'form-control'
+                     class: 'form-control mb-2'
       %>
     </div>
 
-    <div class='col-2'>
-      <%= submit_tag 'Add', class: 'btn btn-outline-info' %>
+    <div class="col-auto">
+      <%= submit_tag 'Add', class: 'btn btn-outline-info mb-2' %>
     </div>
-  </div> <!-- row -->
+  </div>
 <% end %>

--- a/spec/helpers/ingredients_helper_spec.rb
+++ b/spec/helpers/ingredients_helper_spec.rb
@@ -5,8 +5,14 @@ require 'rails_helper'
 RSpec.describe IngredientsHelper, type: :helper do
   describe 'ingredient_display' do
     it "displays an ingredient's qty unit and name" do
-      ingredient = build(:ingredient)
+      ingredient = build(:ingredient, preparation_style: nil)
       display_output = "#{ingredient.quantity} #{ingredient.measurement_unit} #{ingredient.name}"
+      expect(helper.ingredient_display(ingredient)).to eq(display_output)
+    end
+
+    it "if present, displays the preparation_style" do
+      ingredient = build(:ingredient, preparation_style: 'styled')
+      display_output = "#{ingredient.quantity} #{ingredient.measurement_unit} #{ingredient.name}: #{ingredient.preparation_style}"
       expect(helper.ingredient_display(ingredient)).to eq(display_output)
     end
   end


### PR DESCRIPTION
## Problems Solved
* moves ingredient preparation style next to ingredient
* allows image to be full width of column
* hides "related recipes" section on mobile
* expands stats, meal plans, and sidebar to 100% on mobile
* fixes width problem on "add to list" form

## Screenshots
### Before
<img width="340" alt="Screenshot 2020-03-22 09 50 34" src="https://user-images.githubusercontent.com/8680712/77252583-c18aac00-6c22-11ea-8304-4787ad4415ad.png">
<img width="675" alt="Screenshot 2020-03-22 09 51 20" src="https://user-images.githubusercontent.com/8680712/77252585-c3546f80-6c22-11ea-82a6-246d1e6cd67e.png">

### After
<img width="332" alt="Screenshot 2020-03-22 09 49 53" src="https://user-images.githubusercontent.com/8680712/77252597-d8310300-6c22-11ea-805a-0e6590ed6099.png">
<img width="330" alt="Screenshot 2020-03-22 09 50 04" src="https://user-images.githubusercontent.com/8680712/77252598-d9623000-6c22-11ea-949b-33fd2fd16f97.png">
<img width="330" alt="Screenshot 2020-03-22 09 50 13" src="https://user-images.githubusercontent.com/8680712/77252599-d9623000-6c22-11ea-97a1-e2ad2c4559c5.png">


## Things Learned
* Needs change over time. It's good to try things out and then adjust them as needs change.
* Bootstrap has classes that hide things for mobile.
* Cherry picking little mini features that i spin off while in the middle of another feature is satisfying. This way i can still move forward while working on something bigger and more complicated.
