### PR TITLE
Remove links to pepperplate

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -107,7 +107,6 @@ class RecipesController < ApplicationController
                                    :image_url,
                                    :instructions,
                                    :notes,
-                                   :pepperplate_url,
                                    :prep_day_instructions,
                                    :prep_time,
                                    :reheat_instructions,

--- a/app/services/user_data_setup.rb
+++ b/app/services/user_data_setup.rb
@@ -21,7 +21,7 @@ class UserDataSetup
     end
 
     def create_default_inventory(user)
-      user.inventories.first_or_create!
+      user.inventories.first_or_create!(items: '')
     end
 
     def populate_aisles(user)

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -30,11 +30,6 @@
     <%= form.text_field :image_url, class: 'form-control' %>
   </div>
 
-  <div class="field">
-    <%= form.label :pepperplate_url %>
-    <%= form.text_field :pepperplate_url, class: 'form-control' %>
-  </div>
-
   <div class="row">
     <div class="field col-sm">
       <%= form.label :servings %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -5,9 +5,6 @@
     <h1><%= @recipe.title %> <small><%= extra_work_flag(@recipe) if current_user.present? %></small></h1>
     <p>
       Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank' %>
-      <% unless @recipe.pepperplate_url.blank? || !current_user&.admin? %>
-       | <%= link_to 'Pepperplate', @recipe.pepperplate_url, title: 'pepperplate', target: '_blank' %>
-      <% end %>
     </p>
   </div>
   <div class="col-1">

--- a/db/seed_fixtures/experimental_recipes.yml
+++ b/db/seed_fixtures/experimental_recipes.yml
@@ -3,8 +3,6 @@
   :source_url: https://www.budgetbytes.com/sesame-tempeh-bowls/
 - :title: Mushroom Tacos
   :source_url: https://www.pepperplate.com/recipes/view.aspx?id=15772708
-- :title: Old Pepperplate recipes
-  :source_url: https://docs.google.com/spreadsheets/d/1sJ52kWpNq28rNRLHCXP6tdkyCrBb0nuaRH40Z0Nib_0/edit#gid=0
 - :title: Smoky tempeh tacos
   :source_url: https://www.emilieeats.com/smoky-tempeh-tostadas-mango-cabbage-slaw/
 - :title: BLTs


### PR DESCRIPTION
## Problems Solved
I no longer have a pepperplate.com account. Displaying links to these old recipes is worthless and confusing. I've removed the form field and links on the show page.

