### PR TITLE
Add delivery dates

### DIFF
--- a/app/controllers/scheduled_deliveries_controller.rb
+++ b/app/controllers/scheduled_deliveries_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+class ScheduledDeliveriesController < ApplicationController
+  before_action :set_scheduled_delivery, only: %i[edit update destroy]
+  before_action :set_shopping_list, only: %i[new create edit update destroy]
+
+  def new
+    @scheduled_delivery = @shopping_list.scheduled_deliveries.new(service_provider: 'HEB')
+  end
+
+  def create
+    @scheduled_delivery = @shopping_list.scheduled_deliveries.new(scheduled_delivery_params)
+    # authorize(@scheduled_delivery)
+
+    if @scheduled_delivery.save
+      redirect_to @shopping_list
+    else
+      render :new
+    end
+  end
+
+  def edit
+    # authorize(@scheduled_delivery)
+  end
+
+  def update
+    # authorize(@scheduled_delivery)
+
+    if @scheduled_delivery.update(scheduled_delivery_params)
+      redirect_to @scheduled_delivery.shopping_list
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    scheduled_delivery = ScheduledDelivery.find(params[:id])
+    # authorize(scheduled_delivery)
+
+    scheduled_delivery.destroy
+    flash[:success] = "Your #{@scheduled_delivery.scheduled_for.to_s(:timestamp)} delivery was deleted."
+    redirect_to @scheduled_delivery.shopping_list
+  end
+
+  private
+
+  def set_scheduled_delivery
+    @scheduled_delivery = ScheduledDelivery.find(params[:id])
+  end
+
+  def set_shopping_list
+    @shopping_list = current_user.shopping_lists.find(params[:shopping_list_id])
+  end
+
+  def scheduled_delivery_params
+    params.require(:scheduled_delivery).permit(:shopping_list_id,
+                                               :service_provider,
+                                               :scheduled_for)
+  end
+
+end

--- a/app/helpers/scheduled_deliveries_helper.rb
+++ b/app/helpers/scheduled_deliveries_helper.rb
@@ -3,7 +3,7 @@
 module ScheduledDeliveriesHelper
   def display_scheduled_deliveries(deliveries)
     deliveries.map do |delivery|
-      "#{delivery.service_provider} #{delivery.scheduled_for.to_s(:timestamp)}".squish
-    end.join(' | ')
+      link_to ("#{delivery.service_provider} #{delivery.scheduled_for.to_s(:timestamp)}".squish), edit_shopping_list_scheduled_delivery_path(delivery.shopping_list, delivery)
+    end.join(' | ').html_safe
   end
 end

--- a/app/helpers/scheduled_deliveries_helper.rb
+++ b/app/helpers/scheduled_deliveries_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ScheduledDeliveriesHelper
+  def display_scheduled_deliveries(deliveries)
+    deliveries.map do |delivery|
+      "#{delivery.service_provider} #{delivery.scheduled_for.to_s(:timestamp)}".squish
+    end.join(' | ')
+  end
+end

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ScheduledDelivery < ApplicationRecord
+  belongs_to :shopping_list
+
+  validates :scheduled_for,
+            :service_provider,
+            presence: true
+
+end

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -7,4 +7,8 @@ class ScheduledDelivery < ApplicationRecord
             :service_provider,
             presence: true
 
+  def self.future
+    where('scheduled_for >= ?', Time.zone.today)
+      .order(scheduled_for: :asc)
+  end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -7,6 +7,7 @@ class ShoppingList < ApplicationRecord
   belongs_to :user
   has_many :shopping_list_items, dependent: :destroy
   has_many :items, class_name: 'ShoppingListItem', dependent: :destroy
+  has_many :scheduled_deliveries, dependent: :destroy
 
   validates :name,
             presence: true,

--- a/app/views/scheduled_deliveries/_form.html.erb
+++ b/app/views/scheduled_deliveries/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_for([shopping_list, scheduled_delivery]) do |form| %>
+  <%= render 'shared/errors', object: scheduled_delivery %>
+
+  <div class='field'>
+    <%= form.label :service_provider %>
+    <%= form.text_field :service_provider,
+      autofocus: true,
+      required: true,
+      placeholder: 'ex: HEB',
+      class: 'form-control'
+    %>
+  </div>
+
+  <div class='field'>
+    <%= form.label :scheduled_for, class: 'mt-3' %><br>
+    <%= form.datetime_select :scheduled_for,
+      required: true,
+      value: Date.today,
+      ampm: true,
+      minute_step: 30,
+      start_hour: 06,
+      end_hour: 22,
+      class: 'form-control'
+    %>
+  </div>
+
+  <%= form.submit class: "#{button_classes} mt-3" %>
+<% end %>

--- a/app/views/scheduled_deliveries/_scheduled_deliveries.html.erb
+++ b/app/views/scheduled_deliveries/_scheduled_deliveries.html.erb
@@ -1,6 +1,6 @@
-<% if shopping_list.scheduled_deliveries.any? %>
+<% if shopping_list.scheduled_deliveries.future.any? %>
   <section>
-    <p><strong>Upcoming Deliveries:</strong>
+    <p><strong>Deliveries:</strong>
       <%= display_scheduled_deliveries(shopping_list.scheduled_deliveries.future) %>
     </p>
   </section>

--- a/app/views/scheduled_deliveries/_scheduled_deliveries.html.erb
+++ b/app/views/scheduled_deliveries/_scheduled_deliveries.html.erb
@@ -1,0 +1,7 @@
+<% if shopping_list.scheduled_deliveries.any? %>
+  <section>
+    <p><strong>Upcoming Deliveries:</strong>
+      <%= display_scheduled_deliveries(shopping_list.scheduled_deliveries.future) %>
+    </p>
+  </section>
+<% end %>

--- a/app/views/scheduled_deliveries/edit.html.erb
+++ b/app/views/scheduled_deliveries/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title, "Edit #{@scheduled_delivery.shopping_list.name}") %>
+
+<h1>
+  <%= link_to "", shopping_list_path(@scheduled_delivery.shopping_list), class: Icon.back %>
+  Editing <%= @scheduled_delivery.scheduled_for.to_s(:timestamp) %>
+</h1>
+
+<%= render 'form', scheduled_delivery: @scheduled_delivery, shopping_list: @shopping_list %>
+<%= link_to 'Delete', shopping_list_scheduled_delivery_path(@shopping_list, @scheduled_delivery), method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: 'btn btn-sm btn-outline-danger mt-5' %>

--- a/app/views/scheduled_deliveries/new.html.erb
+++ b/app/views/scheduled_deliveries/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:title, 'Schedule a Delivery') %>
+
+<h1>
+  <%= link_to "", @shopping_list, class: Icon.back %>
+  Schedule a Delivery
+</h1>
+
+<%= render 'form', scheduled_delivery: @scheduled_delivery, shopping_list: @shopping_list %>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -15,6 +15,8 @@
   <% end %>
 </article>
 
+<%= render 'scheduled_deliveries/scheduled_deliveries', shopping_list: @shopping_list %>
+
 <section id='active-items'>
   <% @shopping_list.shopping_list_items.not_purchased.by_aisle_order_number.group_by(&:aisle).each do |aisle, items| %>
     <% if aisle %>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -2,8 +2,9 @@
 
 <h1>
   <%= link_to "", @shopping_list, title: 'sync', class: "#{Icon.sync} float-right"%>
-  <%= link_to "Clear List", deactivate_all_items_path(@shopping_list), method: :post, data: { confirm: 'Are you sure you want to cross off all items? This action cannot be undone.' }, title: 'clear list', class: button_classes('outline-info float-right mr-5 mt-2') %>
-  <%= link_to "", shopping_lists_path, class: Icon.back %>
+  <%= link_to 'Clear List', deactivate_all_items_path(@shopping_list), method: :post, data: { confirm: 'Are you sure you want to cross off all items? This action cannot be undone.' }, title: 'clear list', class: button_classes('outline-info float-right mr-3 mt-2') %>
+  <%= link_to 'Add Delivery', new_shopping_list_scheduled_delivery_path(@shopping_list), title: 'Schedule an upcoming delivery', class: button_classes('outline-info float-right mr-2 mt-2') %>
+  <%= link_to '', shopping_lists_path, class: Icon.back %>
   <%= @shopping_list.name %>
 </h1>
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,2 +1,10 @@
+# See Docs: https://apidock.com/ruby/DateTime/strftime
+
+# 05-25-2020
 Date::DATE_FORMATS[:default] = "%m-%d-%Y"
+
+# 05/25
 Date::DATE_FORMATS[:short] = "%m/%d"
+
+# Sun 05/25 at 7:22 am
+Time::DATE_FORMATS[:timestamp] = "%a %m/%d at %l:%M %P"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   resources :meal_plan_recipes, only: [:create]
   resources :shopping_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
+    resources :scheduled_deliveries, only: [:new, :create, :edit, :update, :destroy]
     resources :shopping_list_items, only: [:new, :create, :edit, :update, :destroy]
     member do
       get :search

--- a/db/migrate/20200517165415_create_scheduled_deliveries.rb
+++ b/db/migrate/20200517165415_create_scheduled_deliveries.rb
@@ -1,0 +1,11 @@
+class CreateScheduledDeliveries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :scheduled_deliveries do |t|
+      t.datetime :scheduled_for
+      t.string :service_provider
+      t.references :shopping_list, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_000447) do
+ActiveRecord::Schema.define(version: 2020_05_17_165415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,15 @@ ActiveRecord::Schema.define(version: 2020_04_30_000447) do
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 
+  create_table "scheduled_deliveries", force: :cascade do |t|
+    t.datetime "scheduled_for"
+    t.string "service_provider"
+    t.bigint "shopping_list_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shopping_list_id"], name: "index_scheduled_deliveries_on_shopping_list_id"
+  end
+
   create_table "shopping_list_items", force: :cascade do |t|
     t.bigint "shopping_list_id"
     t.bigint "aisle_id"
@@ -161,6 +170,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_000447) do
   add_foreign_key "meal_plan_recipes", "recipes"
   add_foreign_key "meal_plans", "users"
   add_foreign_key "recipes", "users"
+  add_foreign_key "scheduled_deliveries", "shopping_lists"
   add_foreign_key "shopping_list_items", "aisles"
   add_foreign_key "shopping_list_items", "shopping_lists"
   add_foreign_key "shopping_lists", "users"

--- a/spec/factories/scheduled_deliveries.rb
+++ b/spec/factories/scheduled_deliveries.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scheduled_delivery do
+    shopping_list
+    scheduled_for { Time.zone.now.to_s }
+    sequence(:service_provider) { |n| "ServiceProvider#{n}" }
+  end
+end

--- a/spec/helpers/scheduled_deliveries_helper_spec.rb
+++ b/spec/helpers/scheduled_deliveries_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduledDeliveriesHelper, type: :helper do
+  describe 'display_scheduled_deliveries' do
+    it 'displays the day of the week, date, and time' do
+      delivery_date = '2020-05-12 10:00:00 UTC'
+      delivery1 = create(:scheduled_delivery, scheduled_for: delivery_date)
+      deliveries = [delivery1]
+
+      expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery1.service_provider)
+      expect(helper.display_scheduled_deliveries(deliveries)).to include('Tue 05/12 at 10:00 am')
+    end
+
+    it 'joins multiple deliveries with a pipe' do
+      delivery1 = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
+      delivery2 = create(:scheduled_delivery, scheduled_for: 4.days.from_now)
+      deliveries = ScheduledDelivery.all
+
+      expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery1.service_provider)
+      expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery2.service_provider)
+      expect(helper.display_scheduled_deliveries(deliveries)).to include(' | ')
+    end
+
+    it 'display time in 12-hour format' do
+      delivery_date = '2020-05-12 18:00:00 UTC'
+      delivery = create(:scheduled_delivery, scheduled_for: delivery_date)
+
+      expect(helper.display_scheduled_deliveries([delivery])).to include('Tue 05/12 at 6:00 pm')
+    end
+  end
+end

--- a/spec/models/scheduled_delivery_spec.rb
+++ b/spec/models/scheduled_delivery_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduledDelivery, type: :model do
+  context 'associations' do
+    it { should belong_to(:shopping_list) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:service_provider) }
+    it { should validate_presence_of(:scheduled_for) }
+  end
+
+end

--- a/spec/models/scheduled_delivery_spec.rb
+++ b/spec/models/scheduled_delivery_spec.rb
@@ -10,4 +10,23 @@ RSpec.describe ScheduledDelivery, type: :model do
     it { should validate_presence_of(:scheduled_for) }
   end
 
+  describe 'self.future' do
+    it 'only displays upcoming deliveries' do
+      future_delivery = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
+      past_delivery = create(:scheduled_delivery, scheduled_for: 3.days.ago)
+      results = ScheduledDelivery.future
+
+      expect(results).to include(future_delivery)
+      expect(results).to_not include(past_delivery)
+    end
+
+    it 'displays deliveries in ascending order' do
+      second_delivery = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
+      first_delivery = create(:scheduled_delivery, scheduled_for: 2.days.from_now)
+      results = ScheduledDelivery.future
+
+      expect(results.first).to eq(first_delivery)
+      expect(results.last).to eq(second_delivery)
+    end
+  end
 end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ShoppingList, type: :model do
     it { should belong_to(:user) }
     it { should have_many(:shopping_list_items) }
     it { should have_many(:items) }
+    it { should have_many(:scheduled_deliveries) }
   end
 
   describe 'a valid shopping_list' do


### PR DESCRIPTION
## Problems Solved
* Now that we're scheduling deliveries more regularly, it's nice to have a reminder of when the next delivery is happening
* we can add upcoming deliveries to a shopping list
* only "future" deliveries are displayed  -- and disappear after they expire

## Screenshots
<img width="500" alt="Screenshot 2020-05-17 15 13 27" src="https://user-images.githubusercontent.com/8680712/82158999-00b73100-9851-11ea-84a6-cf16fa30ae55.png">
<img width="500" alt="Screenshot 2020-05-17 15 13 33" src="https://user-images.githubusercontent.com/8680712/82159001-01e85e00-9851-11ea-865a-681c4db847ad.png">


## Things Learned
* UX is hard

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
