### PR TITLE
Suggest next plan date

### DIFF
--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -19,7 +19,7 @@ class MealPlansController < ApplicationController
   def new
     default_params = {
       people_served: 2,
-      start_date: MealPlan.date_for_upcoming_sunday
+      start_date: MealPlan.date_after_last_meal_plan(current_user)
     }
     @meal_plan = current_user.meal_plans.new(default_params)
     authorize(@meal_plan)

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -17,8 +17,18 @@ class MealPlan < ApplicationRecord
   scope :by_date, -> { order(start_date: :asc) }
   scope :most_recent_first, -> { order(start_date: :DESC) }
 
+  def self.date_after_last_meal_plan(user)
+    if any?
+      latest_plan_date = user.meal_plans.maximum(:start_date)
+      latest_plan_day_of_week = latest_plan_date.wday
+      days_to_add = (7 - latest_plan_day_of_week)
+      latest_plan_date + days_to_add
+    else
+      date_for_upcoming_sunday
+    end
+  end
+
   def self.date_for_upcoming_sunday
-    # TODO: scope to current_user
     closest_sunday = Date.parse('Sunday')
     days_to_add = closest_sunday > Time.zone.today ? 0 : 7
     closest_sunday + days_to_add

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe MealPlan, type: :model do
-  let(:meal_plan) { build(:meal_plan) }
-
   context 'associations' do
     it { should belong_to(:user) }
     it { should have_many(:meal_plan_recipes) }
@@ -11,6 +9,8 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe 'a valid meal_plan' do
+    let(:meal_plan) { build(:meal_plan) }
+
     context 'when has valid params' do
       it 'is valid' do
         expect(meal_plan).to be_valid
@@ -36,7 +36,61 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  xdescribe 'self.date_for_upcoming_sunday' do
+  describe 'self.date_after_last_meal_plan' do
+    let(:user) { create(:user) }
+    let(:random_wednesday) { '2020-08-05'.to_date }
+
+    it 'chooses a date later than the latest meal plan' do
+      plan1 = create(:meal_plan, user: user, start_date: random_wednesday)
+      new_date = MealPlan.date_after_last_meal_plan(user)
+
+      expect(new_date).to be > plan1.start_date
+    end
+
+    it 'chooses a sunday' do
+      create(:meal_plan, user: user, start_date: random_wednesday)
+      new_date = MealPlan.date_after_last_meal_plan(user)
+      sunday_number = 0
+
+      expect(new_date.wday).to eq(sunday_number)
+    end
+
+    it 'picks upcoming sunday if there are no meal plans for the user' do
+      expect(MealPlan).to receive(:date_for_upcoming_sunday)
+      MealPlan.date_after_last_meal_plan(user)
+    end
+  end
+
+  describe 'self.date_for_upcoming_sunday' do
+    it 'if today is Sunday, it returns today' do
+      today_sunday = '2020-08-02'.to_date
+
+      # Travel to Sunday
+      travel_to Time.zone.local(2020, 8, 02, 01, 04, 44) do
+        new_date = MealPlan.date_for_upcoming_sunday
+        expect(new_date).to eq(today_sunday)
+      end
+    end
+
+    it 'if today is Monday, it returns the upcoming Sunday' do
+      upcoming_sunday = '2020-08-02'.to_date
+
+      # Travel to Monday
+      travel_to Time.zone.local(2020, 07, 27, 01, 04, 44) do
+        new_date = MealPlan.date_for_upcoming_sunday
+        expect(new_date).to eq(upcoming_sunday)
+      end
+    end
+
+    it 'if today is Saturday, it returns tomorrow' do
+      tomorrow = '2020-08-02'.to_date
+
+      # Travel to Saturday
+      travel_to Time.zone.local(2020, 8, 01, 01, 04, 44) do
+        new_date = MealPlan.date_for_upcoming_sunday
+        expect(new_date).to eq(tomorrow)
+      end
+    end
   end
 
   describe 'self.future' do
@@ -80,6 +134,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#total_servings' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:standard_servings) { 2 }
     let(:qty_recipes) { 2 }
 
@@ -98,6 +153,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#total_prep_time' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:standard_prep_time) { 2 }
     let(:qty_recipes) { 2 }
 
@@ -115,6 +171,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#total_cook_time' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:standard_cook_time) { 2 }
     let(:qty_recipes) { 2 }
 
@@ -133,6 +190,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#total_time' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:standard_cook_time) { 2 }
     let(:standard_prep_time) { 2 }
     let(:qty_recipes) { 2 }
@@ -181,6 +239,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#meals' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:standard_servings) { 2 }
     let(:qty_recipes) { 2 }
     let(:total_servings) { standard_servings * qty_recipes }
@@ -200,6 +259,7 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '#total_unique_ingredients' do
+    let(:meal_plan) { build(:meal_plan) }
     let(:qty_recipes) { 2 }
     let(:recipe1) { create(:recipe) }
     let(:recipe2) { create(:recipe) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.infer_base_class_for_anonymous_controllers = false
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view


### PR DESCRIPTION
## Problems Solved
Sometimes i like to build out several weeks of meal plans at once. This work does the math for me so i don't have to reference a calendar to know when the next Sunday is. It takes the date from the latest `meal_plan.start_date`, regardless of what day of the week it is, and auto-populates the form with the next Sunday following that date.

## Things Learned
http://yay-me.herokuapp.com/posts/762

A good use-case for using `expect(X).to_receive(Y)` in testing:
When you have a condition in a method, instead of writing tests for a whole logic tree that may already fall under the jurisdiction of another test, it makes sense to just ask if that method was called.

The method
```ruby
class Kitten
  def self.something_cute_with_kittens(user)
    if any?
      # does a bunch of testable stuff here
    else
      # the method we're going to `expect`
      already_tested_method
    end
  end

  def self.already_tested_method
    # does a bunch of stuff that's tested
  end
end
```

The spec that uses "expect to receive"
```ruby
describe 'self.something_cute_with_kittens' do
  it 'does that expected thing if there arent any kittens' do
    user = create(:user)

    expect(Kitten).to receive(:already_tested_method)
    Kitten.something_cute_with_kittens(user)
  end
end
```

## Due Diligence Checks
- [ ] ~If this work contains migrations, I have updated factories and seeds accordingly~
- [x] I have written new specs for this work
- [x] I have browser tested this work
