### PR TITLE
Rename meal_plan.start_date to prepared_on

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.3'
+gem 'rails', '~> 6.1.0'         # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'coffee-rails'              # Use CoffeeScript for .coffee assets and views
@@ -15,7 +16,6 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 5.1.1'            # Use Puma as the app server
 gem 'pundit'                    # Authorization
 gem 'rack', '>= 2.0.6'          # Upgrade for security update
-gem 'rails', '~> 6.1.0'         # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'sass-rails', '~> 6.0'      # Use SCSS for stylesheets
 gem 'sentry-raven'              # Error reporting in sentry
 gem 'uglifier', '>= 1.3.0'      # Use Uglifier as compressor for JavaScript assets

--- a/app/controllers/meal_plan_recipes_controller.rb
+++ b/app/controllers/meal_plan_recipes_controller.rb
@@ -9,10 +9,10 @@ class MealPlanRecipesController < ApplicationController
     if meal_plan_recipe.save
       redirect_back(
         fallback_location: recipes_url,
-        notice: "#{@recipe.title} added to #{@meal_plan.start_date.to_s(:short)} meal plan"
+        notice: "#{@recipe.title} added to #{@meal_plan.prepared_on.to_s(:short)} meal plan"
       )
     else
-      flash[:error] = "#{@recipe.title} was already part of the #{@meal_plan.start_date.to_s(:short)} meal plan."
+      flash[:error] = "#{@recipe.title} was already part of the #{@meal_plan.prepared_on.to_s(:short)} meal plan."
       redirect_back(fallback_location: recipes_url)
     end
   end

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -19,7 +19,7 @@ class MealPlansController < ApplicationController
   def new
     default_params = {
       people_served: 2,
-      start_date: MealPlan.suggested_date(current_user)
+      prepared_on: MealPlan.suggested_date(current_user)
     }
     @meal_plan = current_user.meal_plans.new(default_params)
     authorize(@meal_plan)
@@ -30,7 +30,7 @@ class MealPlansController < ApplicationController
     existing_recipes = @meal_plan.recipes
     @meal_plan = @meal_plan.dup
     @meal_plan.recipes << existing_recipes
-    @meal_plan.start_date = nil
+    @meal_plan.prepared_on = nil
 
     render :new
   end
@@ -54,7 +54,7 @@ class MealPlansController < ApplicationController
     authorize(@meal_plan)
 
     if @meal_plan.update(meal_plan_params)
-      redirect_to meal_plan_url(@meal_plan), notice: "#{@meal_plan.start_date} Meal Plan Updated"
+      redirect_to meal_plan_url(@meal_plan), notice: "#{@meal_plan.prepared_on} Meal Plan Updated"
     else
       render :edit
     end
@@ -65,7 +65,7 @@ class MealPlansController < ApplicationController
     authorize(meal_plan)
 
     meal_plan.destroy
-    flash[:success] = "#{meal_plan.start_date} Meal Plan deleted"
+    flash[:success] = "#{meal_plan.prepared_on} Meal Plan deleted"
     redirect_to meal_plans_path
   end
 
@@ -76,6 +76,6 @@ class MealPlansController < ApplicationController
   end
 
   def meal_plan_params
-    params.require(:meal_plan).permit(:start_date, :people_served, :notes, recipe_ids: [])
+    params.require(:meal_plan).permit(:prepared_on, :people_served, :notes, recipe_ids: [])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
 
   def display_link_to_plan
     upcoming = current_user.meal_plans.upcoming
-    link_to "Meal Plan: #{upcoming.start_date.to_s(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
+    link_to "Meal Plan: #{upcoming.prepared_on.to_s(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
   end
 
   def display_list_and_count

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -7,18 +7,18 @@ class MealPlan < ApplicationRecord
   has_many :ingredients, through: :recipes
 
   validates :people_served, presence: true
-  validates :start_date,
+  validates :prepared_on,
             presence: true,
             uniqueness: { scope: :user_id }
 
   PREP_END_TIME = Time.zone.parse('5:00 PM')
   EFFICIENCY_RATE = 0.66
 
-  scope :by_date, -> { order(start_date: :asc) }
-  scope :most_recent_first, -> { order(start_date: :DESC) }
+  scope :by_date, -> { order(prepared_on: :asc) }
+  scope :most_recent_first, -> { order(prepared_on: :DESC) }
 
   def self.future
-    where('start_date >= ?', Time.zone.today).by_date
+    where('prepared_on >= ?', Time.zone.today).by_date
   end
 
   def self.upcoming
@@ -29,7 +29,7 @@ class MealPlan < ApplicationRecord
     upcoming_sunday = Date.today.next_occurring(:sunday)
     return upcoming_sunday if user.meal_plans.blank?
 
-    latest_plan_date = user.meal_plans.maximum(:start_date)
+    latest_plan_date = user.meal_plans.maximum(:prepared_on)
     oldest_allowable_date = 7.days.ago
 
     if latest_plan_date < oldest_allowable_date
@@ -109,7 +109,7 @@ class MealPlan < ApplicationRecord
   #
   # def enqueue_recipes
   #   qty_meals.times do
-  #     @recipe_queue << add_to_calendar_url(@start_date)
+  #     @recipe_queue << add_to_calendar_url(@prepared_on)
   #   end
   #   @recipe_queue.count
   # end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -43,7 +43,7 @@ class Recipe < ApplicationRecord
   end
 
   def self.by_last_prepared
-    order('meal_plans.start_date asc')
+    order('meal_plans.prepared_on asc')
   end
 
   def self.active
@@ -69,7 +69,7 @@ class Recipe < ApplicationRecord
   end
 
   def last_prepared
-    meal_plans.pluck(:start_date).max
+    meal_plans.pluck(:prepared_on).max
   end
 
   def total_time

--- a/app/views/meal_plans/_form.html.erb
+++ b/app/views/meal_plans/_form.html.erb
@@ -3,9 +3,9 @@
 
   <form>
     <div class="form-group row">
-      <%= form.label :start_date, class: 'col-sm-3 col-form-label' %>
+      <%= form.label :prepared_on, class: 'col-sm-3 col-form-label' %>
       <div class="col-sm-9">
-        <%= form.date_field :start_date, autofocus: true, class: 'form-control' %>
+        <%= form.date_field :prepared_on, autofocus: true, class: 'form-control' %>
       </div>
     </div>
 

--- a/app/views/meal_plans/edit.html.erb
+++ b/app/views/meal_plans/edit.html.erb
@@ -1,6 +1,6 @@
 <%= link_to 'Cancel', meal_plans_path, class: "#{button_classes} float-right" %>
 
-<h1>Edit the Plan for <%= @meal_plan.start_date.to_s(:long) %> </h1>
+<h1>Edit the Plan for <%= @meal_plan.prepared_on.to_s(:long) %> </h1>
 
 <%= render 'form', meal_plan: @meal_plan %>
 

--- a/app/views/meal_plans/index.html.erb
+++ b/app/views/meal_plans/index.html.erb
@@ -8,7 +8,7 @@
   <div class="card mb-3">
     <div class="card-body">
       <h5 class="card-title controls-on-right-parent">
-        <%= link_to "#{l plan.start_date, format: :month_as_text}", meal_plan_path(plan) %>
+        <%= link_to "#{l plan.prepared_on, format: :month_as_text}", meal_plan_path(plan) %>
         <span class='controls'>
           <%= link_to 'Copy', copy_meal_plan_path(plan), title: 'Make a copy of this meal plan', class: button_classes %>
           <%= link_to 'Edit', edit_meal_plan_path(plan), title: 'Edit this meal plan', class: button_classes %>

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for(:title, "Food Prep #{@meal_plan.start_date}") %>
+<% content_for(:title, "Food Prep #{@meal_plan.prepared_on}") %>
 <div class="float-right"><%= link_to 'Edit', edit_meal_plan_path(@meal_plan), class: button_classes %></div>
 
-<h1>Meal Plan for <%= @meal_plan.start_date.to_s(:long) %></h1>
+<h1>Meal Plan for <%= @meal_plan.prepared_on.to_s(:long) %></h1>
 
 <div class="row">
   <section class="col-12 col-sm-6">

--- a/app/views/recipes/_add_to_meal_plan_dropdown.html.erb
+++ b/app/views/recipes/_add_to_meal_plan_dropdown.html.erb
@@ -4,7 +4,7 @@
     <div class='col'>
       <%= form.collection_select :meal_plan_id,
                                  available_meal_plans_dropdown(current_user, recipe),
-                                 :id, :start_date, {},
+                                 :id, :prepared_on, {},
                                  class: 'form-control form-control-sm'
       %>
     </div>

--- a/app/views/recipes/_related_meal_plans.html.erb
+++ b/app/views/recipes/_related_meal_plans.html.erb
@@ -6,8 +6,8 @@
 <% end %>
 
 <ul>
-  <% recipe.meal_plans.order(start_date: :desc).limit(5).each do |plan| %>
-    <li><%= link_to "#{l plan.start_date, format: :month_as_text}", plan %></li>
+  <% recipe.meal_plans.order(prepared_on: :desc).limit(5).each do |plan| %>
+    <li><%= link_to "#{l plan.prepared_on, format: :month_as_text}", plan %></li>
   <% end %>
 </ul>
 <% end %>

--- a/db/migrate/20210128014008_change_meal_plan_start_date_column_name.rb
+++ b/db/migrate/20210128014008_change_meal_plan_start_date_column_name.rb
@@ -1,0 +1,9 @@
+class ChangeMealPlanStartDateColumnName < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :meal_plans, :start_date, :prepared_on
+  end
+
+  def down
+    rename_column :meal_plans, :prepared_on, :start_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_13_224324) do
+ActiveRecord::Schema.define(version: 2021_01_28_014008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 2020_12_13_224324) do
   end
 
   create_table "meal_plans", force: :cascade do |t|
-    t.date "start_date", null: false
+    t.date "prepared_on", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "people_served", default: 0, null: false
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2020_12_13_224324) do
     t.text "reheat_instructions", default: ""
     t.text "prep_day_instructions", default: ""
     t.string "extra_work_note"
+    t.date "last_prepared_on"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,7 +118,6 @@ ActiveRecord::Schema.define(version: 2021_01_28_014008) do
     t.text "reheat_instructions", default: ""
     t.text "prep_day_instructions", default: ""
     t.string "extra_work_note"
-    t.date "last_prepared_on"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ ExperimentalRecipe.create!(experimental_recipe_seed_data)
 7.times do |i|
   MealPlan.create!(
     user: user,
-    start_date: i.weeks.ago.beginning_of_week(:sunday),
+    prepared_on: i.weeks.ago.beginning_of_week(:sunday),
     people_served: [2, 4].sample,
     notes: ['plan to one of them in the freezer', '', '', ''].sample
   )

--- a/db/seeds_original.rb
+++ b/db/seeds_original.rb
@@ -707,7 +707,7 @@ gnocchi.ingredients.create!([
 
 5.times do
   MealPlan.create!(
-    start_date: rand((Time.zone.today - 100)...Time.zone.today),
+    prepared_on: rand((Time.zone.today - 100)...Time.zone.today),
     people_served: 2,
     recipes: Recipe.all.sample(rand(2..5))
   )

--- a/spec/factories/meal_plans.rb
+++ b/spec/factories/meal_plans.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :meal_plan do
     user
-    start_date { rand((Time.zone.today - 10)...Time.zone.today) }
+    prepared_on { rand((Time.zone.today - 10)...Time.zone.today) }
     people_served { 2 }
     notes { '' }
   end

--- a/spec/features/recipes_show_page_authorization.rb
+++ b/spec/features/recipes_show_page_authorization.rb
@@ -7,9 +7,9 @@ RSpec.feature 'Recipes Show page viewable by user role', type: :feature do
   let!(:other_user) { create(:user) }
   let!(:author_recipe) { create(:recipe, user: author) }
   let!(:shopping_list) { create(:shopping_list, user: author) }
-  let!(:author_meal_plan) { create(:meal_plan, user: author, start_date: Time.zone.now + 10) }
+  let!(:author_meal_plan) { create(:meal_plan, user: author, prepared_on: Time.zone.now + 10) }
   let!(:author_meal_plan_recipe) { create(:meal_plan_recipe, meal_plan: author_meal_plan) }
-  let!(:other_user_meal_plan) { create(:meal_plan, user: other_user, start_date: Time.zone.now + 10) }
+  let!(:other_user_meal_plan) { create(:meal_plan, user: other_user, prepared_on: Time.zone.now + 10) }
   let!(:other_user_meal_plan_recipe) { create(:meal_plan_recipe, meal_plan: other_user_meal_plan) }
 
   describe 'recipes viewable without authentication and by non-authors' do

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe RecipesHelper, type: :helper do
     it 'returns "been a while" when recipe has not been made in the past 4 months' do
       recipe = create(:recipe)
       four_months_ago = Time.zone.today - 5.months
-      recipe.meal_plans << create(:meal_plan, start_date: four_months_ago)
+      recipe.meal_plans << create(:meal_plan, prepared_on: four_months_ago)
 
       expect(helper.status_flag(recipe)).to include('assets/icon_')
     end
 
     it 'does not return a flag when recipe has no conditions' do
       recipe = create(:recipe)
-      recipe.meal_plans << create(:meal_plan, start_date: Time.zone.today)
+      recipe.meal_plans << create(:meal_plan, prepared_on: Time.zone.today)
 
       expect(helper.status_flag(recipe)).to eq('')
     end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -17,19 +17,19 @@ RSpec.describe MealPlan, type: :model do
       end
     end
 
-    it { should validate_presence_of(:start_date) }
+    it { should validate_presence_of(:prepared_on) }
     it { should validate_presence_of(:people_served) }
 
-    it 'has a unique start_date scoped to user' do
+    it 'has a unique prepared_on scoped to user' do
       create(:meal_plan)
-      should validate_uniqueness_of(:start_date).scoped_to(:user_id)
+      should validate_uniqueness_of(:prepared_on).scoped_to(:user_id)
     end
   end
 
   describe 'self.most_recent_first' do
-    it 'displays all meal plans in descending start_date order' do
-      meal_plan1 = create(:meal_plan, start_date: Time.zone.yesterday)
-      meal_plan2 = create(:meal_plan, start_date: Time.zone.today)
+    it 'displays all meal plans in descending prepared_on order' do
+      meal_plan1 = create(:meal_plan, prepared_on: Time.zone.yesterday)
+      meal_plan2 = create(:meal_plan, prepared_on: Time.zone.today)
 
       expect(MealPlan.most_recent_first.first).to eq(meal_plan2)
       expect(MealPlan.most_recent_first.last).to eq(meal_plan1)
@@ -54,7 +54,7 @@ RSpec.describe MealPlan, type: :model do
       seven_days_ago = '2020-07-26'.to_date
       upcoming_sunday = '2020-08-02'.to_date
       latest_plan_date = '2020-07-25'.to_date
-      create(:meal_plan, user: user, start_date: latest_plan_date)
+      create(:meal_plan, user: user, prepared_on: latest_plan_date)
 
       # Travel to today_saturday
       travel_to Time.zone.local(2020, 8, 0o1, 0o1, 0o4, 44) do
@@ -68,7 +68,7 @@ RSpec.describe MealPlan, type: :model do
       seven_days_ago = '2020-07-26'.to_date
       upcoming_sunday = '2020-08-02'.to_date
       latest_plan_date = '2020-07-28'.to_date
-      create(:meal_plan, user: user, start_date: latest_plan_date)
+      create(:meal_plan, user: user, prepared_on: latest_plan_date)
 
       # Travel to today_saturday
       travel_to Time.zone.local(2020, 8, 0o1, 0o1, 0o4, 44) do
@@ -83,14 +83,14 @@ RSpec.describe MealPlan, type: :model do
     let(:random_wednesday) { '2020-08-05'.to_date }
 
     it 'chooses a date later than the latest meal plan' do
-      plan1 = create(:meal_plan, user: user, start_date: random_wednesday)
+      plan1 = create(:meal_plan, user: user, prepared_on: random_wednesday)
       new_date = MealPlan.date_after_last_meal_plan(random_wednesday)
 
-      expect(new_date).to be > plan1.start_date
+      expect(new_date).to be > plan1.prepared_on
     end
 
     it 'chooses a sunday' do
-      create(:meal_plan, user: user, start_date: random_wednesday)
+      create(:meal_plan, user: user, prepared_on: random_wednesday)
       new_date = MealPlan.date_after_last_meal_plan(random_wednesday)
       sunday_number = 0
 
@@ -101,10 +101,10 @@ RSpec.describe MealPlan, type: :model do
   describe 'self.future' do
     it 'returns a list of meal plans starting today or in the future' do
       user = build(:user)
-      past_plan = create(:meal_plan, user: user, start_date: Time.zone.today - 2)
-      todays_plan = create(:meal_plan, user: user, start_date: Time.zone.today)
-      upcoming_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 2)
-      future_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 4)
+      past_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today - 2)
+      todays_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today)
+      upcoming_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 2)
+      future_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 4)
 
       future_plans = user.meal_plans.future
       expect(future_plans).to_not include(past_plan)
@@ -117,9 +117,9 @@ RSpec.describe MealPlan, type: :model do
   describe 'upcoming' do
     it 'returns a single meal plan' do
       user = build(:user)
-      past_plan = create(:meal_plan, user: user, start_date: Time.zone.today - 2)
-      upcoming_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 2)
-      future_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 4)
+      past_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today - 2)
+      upcoming_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 2)
+      future_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 4)
 
       user_upcoming_plan = user.meal_plans.upcoming
       expect(user_upcoming_plan).to_not eq(past_plan)
@@ -129,8 +129,8 @@ RSpec.describe MealPlan, type: :model do
 
     it 'returns the meal plan that is next closest in the future to today' do
       user = build(:user)
-      upcoming_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 2)
-      future_plan = create(:meal_plan, user: user, start_date: Time.zone.today + 4)
+      upcoming_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 2)
+      future_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 4)
 
       user_upcoming_plan = user.meal_plans.upcoming
       expect(user_upcoming_plan).to eq(upcoming_plan)

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Recipe, type: :model do
   describe 'self.by_last_prepared' do
     it 'puts recipes that have not been made in a while on top' do
       recent_recipe = create(:recipe)
-      create(:meal_plan, recipes: [recent_recipe], start_date: '2020-06-15')
+      create(:meal_plan, recipes: [recent_recipe], prepared_on: '2020-06-15')
       old_recipe = create(:recipe)
-      create(:meal_plan, recipes: [old_recipe], start_date: '2018-06-15')
+      create(:meal_plan, recipes: [old_recipe], prepared_on: '2018-06-15')
       ordered_recipes = Recipe.includes(:meal_plans, :meal_plan_recipes).by_last_prepared
 
       expect(ordered_recipes.first).to eq(old_recipe)
@@ -64,15 +64,15 @@ RSpec.describe Recipe, type: :model do
   end
 
   describe '#last_prepared' do
-    let(:meal_plan_today) { create(:meal_plan, start_date: Time.zone.today) }
-    let(:meal_plan_yesterday) { create(:meal_plan, start_date: Time.zone.yesterday) }
+    let(:meal_plan_today) { create(:meal_plan, prepared_on: Time.zone.today) }
+    let(:meal_plan_yesterday) { create(:meal_plan, prepared_on: Time.zone.yesterday) }
     let(:recipe) { create(:recipe) }
 
-    it 'returns the start_date of the most recent meal plan this recipe was included in' do
+    it 'returns the prepared_on of the most recent meal plan this recipe was included in' do
       meal_plan_today.recipes << recipe
       meal_plan_yesterday.recipes << recipe
 
-      expect(recipe.last_prepared).to eq(meal_plan_today.start_date)
+      expect(recipe.last_prepared).to eq(meal_plan_today.prepared_on)
     end
   end
 

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe 'MealPlans', type: :request do
     end
 
     it 'renders meal_plans#update' do
-      new_start_date = Time.zone.now + 15
-      patch meal_plan_path(user_meal_plan, meal_plan: { start_date: new_start_date })
+      new_prepared_on = Time.zone.now + 15
+      patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: new_prepared_on })
 
       expect(response).to redirect_to meal_plan_url(user_meal_plan)
     end
@@ -136,8 +136,8 @@ RSpec.describe 'MealPlans', type: :request do
     end
 
     it 'denies access to meal_plans#update' do
-      new_start_date = 'completely different start_date'
-      patch meal_plan_path(user2_meal_plan, meal_plan: { start_date: new_start_date })
+      new_prepared_on = 'completely different prepared_on'
+      patch meal_plan_path(user2_meal_plan, meal_plan: { prepared_on: new_prepared_on })
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url


### PR DESCRIPTION
## Related Issues & PRs
Related to #372

## Problems Solved
* `start_date` was kind of a weird name. `prepared_on` seems to make more sense given how we use it. 

## Things Learned
* I had let the scope of #372 spiral a little bit. I broke this piece out of that PR so the diff is single-purpose and will make building out the new functionality #372 easier to read in the diff. 

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have updated specs for this work
- [x] I have browser tested this work
