### PR TITLE
Adjust spacing around ingredient checkboxes

### DIFF
--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -40,10 +40,10 @@
     <div class='row'>
       <div class='col-12'>
         <h3>Ingredients</h3>
-        <div class='ml-3'>
+        <div class='ml-3 mb-4'>
           <% @recipe.ingredients.by_id.each do |ingredient| %>
             <input type="checkbox">
-            <label><%= ingredient_display(ingredient) %></label><br>
+            <label class="mb-0"><%= ingredient_display(ingredient) %></label><br>
           <% end %>
         </div>
       </div> <!-- col-12 -->


### PR DESCRIPTION
Reduces spaces around checkbox line items and adds some bottom margin to the section:
<img width="393" alt="Screen Shot 2021-04-26 at 6 57 07 PM" src="https://user-images.githubusercontent.com/8680712/116165328-431ff980-a6c1-11eb-8df1-7fcb9d682830.png">
