### PR TITLE
Revert "Bump pundit from 2.1.1 to 2.2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       thor (>= 0.18.1)
     guard-rspec (1.2.2)
       guard (>= 1.1)
-    i18n (1.9.1)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jbuilder (2.11.5)
@@ -280,7 +280,7 @@ GEM
       nio4r (~> 2.0)
     puma (5.6.1-java)
       nio4r (~> 2.0)
-    pundit (2.2.0)
+    pundit (2.1.1)
       activesupport (>= 3.0.0)
     racc (1.6.0)
     racc (1.6.0-java)
@@ -459,7 +459,7 @@ GEM
     will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.4)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   java


### PR DESCRIPTION
Reverts lortza/food_planner#494

This failed to deploy to heroku and i don't know why yet, so i'm just going to get it out of the way.