### PR TITLE
Add x86_64-linux to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -397,6 +399,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print


### PR DESCRIPTION
Continuing on the troubleshooting from #497, I'm adding a new platform to the gemfile lock to hopefully resolve this heroku fail log output: 

```
-----> Installing dependencies using bundler 2.2.33

       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4

       Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform

       is x86_64-linux. Add the current platform to the lockfile with `bundle lock

       --add-platform x86_64-linux` and try again.

       Bundler Output: Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform

       is x86_64-linux. Add the current platform to the lockfile with `bundle lock

       --add-platform x86_64-linux` and try again.

 !     Failed to install gems via Bundler.
 !     Push rejected, failed to compile Ruby app
 !     Push failed
```