### PR TITLE
Add gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'will_paginate', '~> 3.3.0' # pagination. Styles: http://mislav.github.io/wi
 # gem 'mini_magick', '~> 4.8'  # Use ActiveStorage variant
 # gem 'capistrano-rails', group: :development # Use Capistrano for deployment
 gem 'net-smtp', require: false  # Send internet mail via SMTP
+gem 'net-pop', require: false
+gem 'net-imap', require: false
 
 group :development do
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,14 @@ GEM
     minitest (5.16.2)
     msgpack (1.5.4)
     nenv (0.3.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -372,6 +380,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.4)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -428,6 +437,8 @@ DEPENDENCIES
   launchy
   listen
   loofah (>= 2.2.3)
+  net-imap
+  net-pop
   net-smtp
   nokogiri (>= 1.8.5)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
## Problems Solved
My PR #559 upgrading to Ruby 3.1.0 deployed successfully to heroku, but i got the application error and the site would not load. [This stackoverlflow post](https://stackoverflow.com/a/70631962/5009528) recommended adding these gems. Since I had already added the first one, I gave it a go with the other two:
```ruby
gem 'net-pop', require: false
gem 'net-imap', require: false
```
Instead of merging this change directly to `main` and deploying, i tested this work by deploying this branch to heroku first. This way i could always redeploy `main`. This branch deployed successfully and with site loaded, so i believe we've found our culprit.
