### PR TITLE
Add option to display nutritional data panel from cronometer.com

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@ Closes #X
 - [ ] If this work contains migrations, I have updated factories and seeds accordingly
 - [ ] I have written new specs for this work
 - [ ] I have browser tested this work
+- [ ] I have deployed the feature branch to production and browser tested it successfully

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/BlockLength:
   CountComments: false
 
 Metrics/MethodLength:
-  IgnoredMethods: []
+  AllowedMethods: []
   CountComments: false
   Max: 15
 
@@ -55,6 +55,8 @@ Style/Documentation:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/HashEachMethods:
+  Enabled: false
+Style/HashSyntax:
   Enabled: false
 Style/HashTransformKeys:
   Enabled: false

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -105,6 +105,7 @@ class RecipesController < ApplicationController
                                    :image_url,
                                    :instructions,
                                    :notes,
+                                   :nutrition_data_iframe,
                                    :prep_day_instructions,
                                    :prep_time,
                                    :reheat_instructions,

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -80,20 +80,6 @@ class Recipe < ApplicationRecord
     self.instructions = instructions.tr("\r", "\n")
   end
 
-  def cronometer_iframe
-    '<iframe title="CRONOMETER.com" width="320" height="540" src="https://cronometer.com/facts.html?food=20827757&measure=57479125&labelType=AMERICAN" frameborder="0"></iframe>'
-  end
-
-  def food_number
-    # '20318194'
-    cronometer_iframe.split("food=").last.split("&").first
-  end
-
-  def measure_number
-    # '56144522'
-    cronometer_iframe.split("measure=").last.split("&").first
-  end
-
   def extra_work_required?
     extra_work_note.present?
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -80,6 +80,20 @@ class Recipe < ApplicationRecord
     self.instructions = instructions.tr("\r", "\n")
   end
 
+  def cronometer_iframe
+    '<iframe title="CRONOMETER.com" width="320" height="540" src="https://cronometer.com/facts.html?food=20827757&measure=57479125&labelType=AMERICAN" frameborder="0"></iframe>'
+  end
+
+  def food_number
+    # '20318194'
+    cronometer_iframe.split("food=").last.split("&").first
+  end
+
+  def measure_number
+    # '56144522'
+    cronometer_iframe.split("measure=").last.split("&").first
+  end
+
   def extra_work_required?
     extra_work_note.present?
   end

--- a/app/services/cronometer_parser.rb
+++ b/app/services/cronometer_parser.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CronometerParser
+  attr_reader :raw_iframe_code
+  def initialize(raw_iframe_code)
+    @raw_iframe_code = raw_iframe_code
+  end
+
+  def sanitized_iframe_src
+    "https://cronometer.com/facts.html?food=#{food_number}&measure=#{measure_number}&labelType=AMERICAN"
+  end
+
+  def food_number
+    raw_iframe_code.split('food=').last.split('&').first
+  end
+
+  def measure_number
+    raw_iframe_code.split('measure=').last.split('&').first
+  end
+end

--- a/app/services/cronometer_parser.rb
+++ b/app/services/cronometer_parser.rb
@@ -6,15 +6,25 @@ class CronometerParser
     @raw_iframe_code = raw_iframe_code
   end
 
+  def valid_iframe_data?
+    food_number.present? && measure_number.present?
+  end
+
   def sanitized_iframe_src
+    return unless valid_iframe_data?
+
     "https://cronometer.com/facts.html?food=#{food_number}&measure=#{measure_number}&labelType=AMERICAN"
   end
 
+  private
+
   def food_number
-    raw_iframe_code.split('food=').last.split('&').first
+    match = raw_iframe_code.match(/.*food=(\d*)&/)
+    match.present? && match[1].present? ? match[1] : nil
   end
 
   def measure_number
-    raw_iframe_code.split('measure=').last.split('&').first
+    match = raw_iframe_code.match(/.*measure=(\d*)&/)
+    match.present? && match[1].present? ? match[1] : nil
   end
 end

--- a/app/services/cronometer_parser.rb
+++ b/app/services/cronometer_parser.rb
@@ -7,11 +7,13 @@ class CronometerParser
   end
 
   def valid_iframe_data?
+    return false unless raw_iframe_code.present?
+
     food_number.present? && measure_number.present?
   end
 
   def sanitized_iframe_src
-    return unless valid_iframe_data?
+    return nil unless valid_iframe_data?
 
     "https://cronometer.com/facts.html?food=#{food_number}&measure=#{measure_number}&labelType=AMERICAN"
   end
@@ -19,12 +21,12 @@ class CronometerParser
   private
 
   def food_number
-    match = raw_iframe_code.match(/.*food=(\d*)&/)
-    match.present? && match[1].present? ? match[1] : nil
+    match_data = raw_iframe_code.match(/.*food=(\d*)&/)
+    match_data.present? && match_data[1].present? ? match_data[1] : nil
   end
 
   def measure_number
-    match = raw_iframe_code.match(/.*measure=(\d*)&/)
-    match.present? && match[1].present? ? match[1] : nil
+    match_data = raw_iframe_code.match(/.*measure=(\d*)&/)
+    match_data.present? && match_data[1].present? ? match_data[1] : nil
   end
 end

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -62,6 +62,15 @@
   </div>
 
   <div class="row">
+    <div class="col-sm-12">
+      <div class="field">
+        <%= form.label 'Cronometer iframe' %>
+        <%= form.text_area :nutrition_data_iframe, class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
     <div class="col-sm-10">
       <div class="field">
         <%= form.label :notes %>

--- a/app/views/recipes/_nutritional_information.html.erb
+++ b/app/views/recipes/_nutritional_information.html.erb
@@ -1,5 +1,10 @@
-<% if recipe.food_number && recipe.measure_number %>
-  <iframe title="CRONOMETER.com" width="320" height="540" src='https://cronometer.com/facts.html?food=<%= recipe.food_number %>&measure=<%= recipe.measure_number %>&labelType=AMERICAN' frameborder="0"></iframe>
+<% if iframe_parser.valid_iframe_data? %>
+  <iframe title="CRONOMETER.com"
+          width="320"
+          height="540"
+          src='<%= iframe_parser.sanitized_iframe_src %>'
+          frameborder="0"
+  ></iframe>
 <% else %>
-  <p>For nutrition information, enter ingredient details on <%= link_to 'Cronometer.com', 'https://cronometer.com/#foods', target: '_blank' %> then add the iframe code to this recipe.</p>
+  <p>For nutrition information, enter ingredient details on <%= link_to 'Cronometer.com', 'https://cronometer.com/#foods', target: '_blank' %> then copy the iframe code from the Nutrition Data panel and <%= link_to 'add it to this recipe', edit_recipe_path(recipe) %>.</p>
 <% end %>

--- a/app/views/recipes/_nutritional_information.html.erb
+++ b/app/views/recipes/_nutritional_information.html.erb
@@ -1,0 +1,5 @@
+<% if recipe.food_number && recipe.measure_number %>
+  <iframe title="CRONOMETER.com" width="320" height="540" src='https://cronometer.com/facts.html?food=<%= recipe.food_number %>&measure=<%= recipe.measure_number %>&labelType=AMERICAN' frameborder="0"></iframe>
+<% else %>
+  <p>For nutrition information, enter ingredient details on <%= link_to 'Cronometer.com', 'https://cronometer.com/#foods', target: '_blank' %> then add the iframe code to this recipe.</p>
+<% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -107,6 +107,6 @@
 
   <div class='col-md-4 col-sm-12'>
     <h3>Nutrition Facts</h3>
-    <%= render partial: 'nutritional_information', locals: { recipe: @recipe } %>
+    <%= render partial: 'nutritional_information', locals: { recipe: @recipe, iframe_parser: CronometerParser.new(@recipe.nutrition_data_iframe) } %>
   </div> <!-- right column -->
 </div> <!-- row -->

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -64,40 +64,49 @@
   </div>
 </div> <!-- row -->
 
-<h3>Instructions</h3>
-<div class="card mb-5">
-  <div class="card-header">
-    <ul class="nav nav-tabs card-header-tabs">
-      <li class="nav-item">
-        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
-      </li>
-    </ul>
-  </div>
-  <div class="card-body">
-    <div class="tab-content" id="myTabContent">
-      <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
-        <ol>
-          <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
-        </ol>
+<div class='row'>
+  <div class='col-md-8 col-sm-12'>
+    <h3>Instructions</h3>
+    <div class="card mb-5">
+      <div class="card-header">
+        <ul class="nav nav-tabs card-header-tabs">
+          <li class="nav-item">
+            <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
+          </li>
+        </ul>
       </div>
+      <div class="card-body">
+        <div class="tab-content" id="myTabContent">
+          <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
+            <ol>
+              <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+            </ol>
+          </div>
 
-      <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
-        <ol>
-          <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
-        </ol>
-      </div>
+          <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
+            <ol>
+              <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+            </ol>
+          </div>
 
-      <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
-        <ol>
-          <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
-        </ol>
-      </div>
-    </div><!-- tab-content -->
-  </div><!-- card body -->
-</div><!-- card -->
+          <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
+            <ol>
+              <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
+            </ol>
+          </div>
+        </div><!-- tab-content -->
+      </div><!-- card body -->
+    </div><!-- card -->
+  </div> <!-- left column -->
+
+  <div class='col-md-4 col-sm-12'>
+    <h3>Nutrition Facts</h3>
+    <%= render partial: 'nutritional_information', locals: { recipe: @recipe } %>
+  </div> <!-- right column -->
+</div> <!-- row -->

--- a/db/migrate/20221018163452_add_nutrition_data_iframe_to_recipes.rb
+++ b/db/migrate/20221018163452_add_nutrition_data_iframe_to_recipes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNutritionDataIframeToRecipes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :recipes, :nutrition_data_iframe, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_201133) do
+ActiveRecord::Schema.define(version: 2022_10_18_163452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2021_03_26_201133) do
     t.text "prep_day_instructions", default: ""
     t.string "extra_work_note"
     t.date "last_prepared_on"
+    t.text "nutrition_data_iframe"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/db/seed_fixtures/recipes.yml
+++ b/db/seed_fixtures/recipes.yml
@@ -18,6 +18,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=15454393
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Quick Pad Thai
   :source_name: Women's Health Magazine
   :source_url: https://subscribe.hearstmags.com/circulation/shared/index.html
@@ -35,6 +36,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=15772038
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Quiche
   :source_name: Original Creation
   :source_url: "/"
@@ -53,6 +55,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=19998600
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Creamy Lentil Soup
   :source_name: Bob's Red Mill
   :source_url: https://www.bobsredmill.com/recipes/how-to-make/creamed-vegi-soup/
@@ -70,6 +73,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=18529284
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Red Lentil Curry
   :source_name: Jessica in the Kitchen
   :source_url: https://jessicainthekitchen.com/red-lentil-curry-vegan/
@@ -86,6 +90,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22761475
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Blended Red Lentil Soup
   :source_name: Loving it Vegan
   :source_url: https://lovingitvegan.com/vegan-lentil-soup/
@@ -106,6 +111,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22709198
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Caraotas Negras
   :source_name: GOYA
   :source_url: https://www.goya.com/en/recipes/dishes-desserts/caraotas-negras
@@ -123,6 +129,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=20213928
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Arroz Con Gandules Pigeon Peas
   :source_name: GOYA
   :source_url: https://www.goya.com/en/recipes/arroz-con-gandules
@@ -138,6 +145,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=20213636
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Asian Raw Kale Salad
   :source_name: Cookie + Kate
   :source_url: https://cookieandkate.com/2011/raw-kale-asian-salad/
@@ -158,6 +166,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=20582867
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Potato Leek Soup
   :source_name: Bon Appétit
   :source_url: https://www.bonappetit.com/recipe/potato-leek-soup-toasted-nuts-seeds
@@ -189,6 +198,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22778959
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Lentil & Kale Egg Noodle Bowl
   :source_name: Clean and Delicious
   :source_url: https://cleananddelicious.com/2017/10/06/lentil-kale-whole-grain-noodle-bowl/
@@ -208,6 +218,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22997172
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Pierogi Pizza
   :source_name: All Recipes
   :source_url: https://www.allrecipes.com/recipe/245593/pierogi-pizza/
@@ -229,6 +240,7 @@
   :pepperplate_url:
   :notes:
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Sweet Potato Gnocchis
   :source_name: Original Creation
   :source_url: "/"
@@ -247,6 +259,7 @@
   :pepperplate_url:
   :notes:
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Corn Chowder
   :source_name: I Eat Green
   :source_url: http://www.ieatgreen.com/vegan-corn-chowder/
@@ -263,6 +276,7 @@
   :pepperplate_url:
   :notes:
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: City O City Breakfast Burrito
   :source_name: Original Creation
   :source_url: "/"
@@ -279,6 +293,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=19268430
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Curried Satay Veggie Bowls
   :source_name: Jessica In the Kitchen
   :source_url: https://jessicainthekitchen.com/curried-satay-veggie-bowls/
@@ -298,6 +313,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22657139
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Wild Rice and Mushroom Soup
   :source_name: Pinch of Yum
   :source_url: https://pinchofyum.com/instant-pot-wild-rice-soup
@@ -313,6 +329,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=23158236
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Jackfruit Melt Sandwich
   :source_name: Keepin It Kind
   :source_url: http://keepinitkind.com/jackfruit-tuna-melt-sandwich/
@@ -332,6 +349,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=19099296
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Tortilla Soup
   :source_name: Cookie + Kate
   :source_url: https://cookieandkate.com/2013/vegetarian-tortilla-soup/
@@ -365,6 +383,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22025023
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Ginger Broccolini Stir Fry
   :source_name: All Recipes
   :source_url: http://allrecipes.com/recipe/24712/ginger-veggie-stir-fry/
@@ -385,6 +404,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=18986094
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Spicy Black Bean Soup
   :source_name: Cookie + Kate
   :source_url: https://cookieandkate.com/2016/spicy-vegan-black-bean-soup/
@@ -401,6 +421,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22230216
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Chorizo Sweet Potato Skillet
   :source_name: Budget Bytes
   :source_url: http://www.budgetbytes.com/2014/06/chorizo-sweet-potato-skillet/
@@ -430,6 +451,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=15454413
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Sweet Potato Pie
   :source_name: ThroughmyiMedia
   :source_url: https://youtu.be/BOYWrXVGV5E?t=148
@@ -450,6 +472,7 @@
   :pepperplate_url: ''
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: test recipe
   :source_name: Original Creation
   :source_url: "/"
@@ -462,6 +485,7 @@
   :pepperplate_url: ''
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Twice-Baked Sweet Potatoes
   :source_name: Rachael Ray
   :source_url: https://www.rachaelrayshow.com/recipe/15311_Twice_Baked_Sweet_Potatoes
@@ -492,6 +516,7 @@
   :pepperplate_url: ''
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Enfrijoladas
   :source_name: Budget Bytes
   :source_url: https://www.budgetbytes.com/enfrijoladas-tortillas-in-black-bean-sauce/
@@ -528,6 +553,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22709115
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Apricot Lentil Soup
   :source_name: The Stingy Vegan
   :source_url: https://thestingyvegan.com/vegan-lentil-soup/
@@ -551,6 +577,7 @@
   :pepperplate_url:
   :notes:
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Spicy Roasted Cauliflower with Queso
   :source_name: Budget Bytes
   :source_url: https://www.budgetbytes.com/spicy-roasted-cauliflower-cheese-sauce/
@@ -581,6 +608,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22615064
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Bread Pudding with Roasted Vegetables
   :source_name: Taste Love and Nourish
   :source_url: http://www.tasteloveandnourish.com/2013/09/16/savory-vegetable-bread-pudding/
@@ -611,6 +639,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=15772212
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Sample Archived Recipe
   :source_name: Original Creation
   :source_url: "/"
@@ -623,6 +652,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22709198
   :notes: This recipe was poooo! so it's archived now.
   :archived: true
+  :nutrition_data_iframe: ''
 - :title: Cashew Vegan Queso
   :source_name: Minimalist Baker
   :source_url: https://minimalistbaker.com/roasted-jalapeno-vegan-queso-7-ingredients/
@@ -649,6 +679,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22615079
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Greek Stuffed Peppers
   :source_name: Edible Perspecitve
   :source_url: http://www.edibleperspective.com/home/2013/10/8/greek-stuffed-peppers.html
@@ -684,6 +715,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=17619375
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Shakshuka
   :source_name: Serious Eats
   :source_url: http://www.seriouseats.com/recipes/2016/09/shakshuka-north-african-shirred-eggs-tomato-pepper-recipe.html
@@ -712,6 +744,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=18051887
   :notes: "vasu says he makes this and he doesn't like lame ass southern indian food\r\n"
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Yellow Lentil Dal
   :source_name: Food & Wine
   :source_url: https://www.foodandwine.com/recipes/yellow-lentil-dal-with-fragrant-basmati-rice
@@ -738,6 +771,7 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=22515951
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''
 - :title: Creamy Cherry Tomato & Summer Squash Gnocchi
   :source_name: Cookie + Kate
   :source_url: http://cookieandkate.com/2015/creamy-cherry-tomato-summer-squash-pasta/
@@ -771,3 +805,4 @@
   :pepperplate_url: http://www.pepperplate.com/recipes/view.aspx?id=16885372
   :notes: ''
   :archived: false
+  :nutrition_data_iframe: ''

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     sequence(:source_name) { |n| "Recipe Source #{n}" }
     sequence(:source_url) { |n| "http://recipesource#{n}.com" }
     prep_time { rand(0..20) }
+    nutrition_data_iframe { '' }
     cook_time { rand(0..60) }
     reheat_time { rand(0..60) }
     servings { rand(1..10) }

--- a/spec/services/cronometer_parser_spec.rb
+++ b/spec/services/cronometer_parser_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CronometerParser, type: :service do
+  let(:parser) { CronometerParser.new(valid_iframe_code) }
+  let(:valid_iframe_code) { "<iframe title=\'CRONOMETER.com\' width=\'320\' height=\'540\' src=\'https://cronometer.com/facts.html?#{food_arg}&#{measure_arg}&labelType=AMERICAN\' frameborder=\'0\'></iframe>" }
+  let(:valid_food_arg) { 'food=12345678' }
+  let(:valid_measure_arg) { 'measure=87654321' }
+  let(:food_arg) { valid_food_arg }
+  let(:measure_arg) { valid_measure_arg }
+
+  describe 'valid_iframe_data?' do
+    describe 'when the food_number is present and the measure_number is present' do
+      it 'returns true' do
+        allow(parser).to receive(:food_number).and_return('12345678')
+        allow(parser).to receive(:measure_number).and_return('87654321')
+        expect(parser.valid_iframe_data?).to be(true)
+      end
+    end
+
+    describe 'when the food_number is present and the measure_number is NOT present' do
+      it 'returns true' do
+        allow(parser).to receive(:food_number).and_return('12345678')
+        allow(parser).to receive(:measure_number).and_return(nil)
+        expect(parser.valid_iframe_data?).to be(false)
+      end
+    end
+
+    describe 'when the food_number is NOT present and the measure_number is present' do
+      it 'returns true' do
+        allow(parser).to receive(:food_number).and_return(nil)
+        allow(parser).to receive(:measure_number).and_return('87654321')
+        expect(parser.valid_iframe_data?).to be(false)
+      end
+    end
+
+    describe 'when the food_number is NOT present and the measure_number is NOT present' do
+      it 'returns true' do
+        allow(parser).to receive(:food_number).and_return(nil)
+        allow(parser).to receive(:measure_number).and_return(nil)
+        expect(parser.valid_iframe_data?).to be(false)
+      end
+    end
+  end
+
+  describe 'sanitized_iframe_src' do
+    describe 'when the required data is valid' do
+      it 'returns the expected url' do
+        allow(parser).to receive(:valid_iframe_data?).and_return(true)
+        expected_url = "https://cronometer.com/facts.html?food=12345678&measure=87654321&labelType=AMERICAN"
+        expect(parser.sanitized_iframe_src).to eq(expected_url)
+      end
+    end
+
+    describe 'when the required data is not valid' do
+      it 'returns nil' do
+        allow(parser).to receive(:valid_iframe_data?).and_return(false)
+        expect(parser.sanitized_iframe_src).to be(nil)
+      end
+    end
+  end
+
+  describe 'private matching methods' do
+    let(:invalid_iframe_code) { 'oh hi there & good day&to you' }
+
+    describe 'private.food_number' do
+      describe 'when there is no food argument or data' do
+        let(:food_arg) { '' }
+        it 'returns nil' do
+          expect(parser.send(:food_number)).to be(nil)
+        end
+      end
+
+      describe 'when the food arg is present, but there is no data' do
+        let(:food_arg) { 'food=' }
+        it 'returns nil' do
+          expect(parser.send(:food_number)).to be(nil)
+        end
+      end
+
+      describe 'when the food data is not a number' do
+        let(:food_arg) { 'food=foosbars' }
+        it 'returns nil' do
+          expect(parser.send(:food_number)).to be(nil)
+        end
+      end
+
+      describe 'when the food data is a mix of numbers and characters' do
+        let(:food_arg) { 'food=f00sb44rs' }
+        it 'returns nil' do
+          expect(parser.send(:food_number)).to be(nil)
+        end
+      end
+
+      describe 'when there is a match' do
+        it 'returns 12345678 as its value' do
+          expect(parser.send(:food_number)).to eq('12345678')
+        end
+      end
+    end
+
+    describe 'private.measure_number' do
+      describe 'when there is no measure argument or data' do
+        let(:measure_arg) { '' }
+        it 'returns nil' do
+          expect(parser.send(:measure_number)).to be(nil)
+        end
+      end
+
+      describe 'when the measure arg is present, but there is no data' do
+        let(:measure_arg) { 'measure=' }
+        it 'returns nil' do
+          expect(parser.send(:measure_number)).to be(nil)
+        end
+      end
+
+      describe 'when the measure data is not a number' do
+        let(:measure_arg) { 'measure=foosbars' }
+        it 'returns nil' do
+          expect(parser.send(:measure_number)).to be(nil)
+        end
+      end
+
+      describe 'when the measure data is a mix of numbers and characters' do
+        let(:measure_arg) { 'measure=f00sb44rs' }
+        it 'returns nil' do
+          expect(parser.send(:measure_number)).to be(nil)
+        end
+      end
+
+      describe 'when there is a match' do
+        it 'returns 87654321 as its value' do
+          expect(parser.send(:measure_number)).to eq('87654321')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/cronometer_parser_spec.rb
+++ b/spec/services/cronometer_parser_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe CronometerParser, type: :service do
-  let(:parser) { CronometerParser.new(valid_iframe_code) }
+  let(:parser) { CronometerParser.new(iframe_code) }
+  let(:iframe_code) { valid_iframe_code }
   let(:valid_iframe_code) { "<iframe title=\'CRONOMETER.com\' width=\'320\' height=\'540\' src=\'https://cronometer.com/facts.html?#{food_arg}&#{measure_arg}&labelType=AMERICAN\' frameborder=\'0\'></iframe>" }
   let(:valid_food_arg) { 'food=12345678' }
   let(:valid_measure_arg) { 'measure=87654321' }
@@ -11,6 +12,20 @@ RSpec.describe CronometerParser, type: :service do
   let(:measure_arg) { valid_measure_arg }
 
   describe 'valid_iframe_data?' do
+    describe 'when the raw_iframe_code is nil' do
+      let(:iframe_code) { nil }
+      it 'returns false' do
+        expect(parser.valid_iframe_data?).to be(false)
+      end
+    end
+
+    describe 'when the raw_iframe_code is an empty string' do
+      let(:iframe_code) { '' }
+      it 'returns false' do
+        expect(parser.valid_iframe_data?).to be(false)
+      end
+    end
+
     describe 'when the food_number is present and the measure_number is present' do
       it 'returns true' do
         allow(parser).to receive(:food_number).and_return('12345678')


### PR DESCRIPTION
## Problems Solved
I've been meaning to do a ton of work to get nutrition information into this app and I just haven't done it [years keeps on passing by]. I have been using the very thorough cronometer.com site to help me understand recipe ingredient breakdown. As I've been trying to find another solution to help me with meal planning, so far, everything else is disappointing. I really prefer my own app. 🤷 To help with nutritional data in the meantime, I've added a way to display the data from cronometer on the recipe show page. This seems like the easiest lift right now.

This approach has its limitations since it requires:
* all users (ahem, me) to have a cronometer account
* the user to create a custom recipe in cronometer and then copy the iframe src into the recipe in this app


## Screenshots
I've added the nutritional panel to the right column next to the instructions.
<img width="1137" alt="Screen Shot 2022-10-18 at 4 22 33 PM" src="https://user-images.githubusercontent.com/8680712/196547484-9b7b0d2e-f28a-4ae3-a10b-84b526243f87.png">

## Things Learned
* Ug. Regex. My skills are always imperfect
* I'm glad i deployed the feature branch to production before merging master because i found (and easily fixed) a bug. It would be neat to have a staging environment. 

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
