### PR TITLE
Add pluralization to ingredient displays

### DIFF
--- a/app/helpers/ingredients_helper.rb
+++ b/app/helpers/ingredients_helper.rb
@@ -2,28 +2,28 @@
 
 module IngredientsHelper
   def ingredient_display(ingredient)
-    display_name = [
-      qty_display(ingredient),
-      ingredient.measurement_unit,
-      ingredient.name,
-    ].join(' ')
-
-    if ingredient.preparation_style.present?
-      "#{display_name}: #{ingredient.preparation_style}"
+    display_name = if Ingredient::DESCRIPTIVE_UNITS.include?(ingredient.measurement_unit)
+      pluralize(qty_display(ingredient), "#{ingredient.measurement_unit} #{ingredient.name}")
     else
-      display_name
+      "#{pluralize(qty_display(ingredient), ingredient.measurement_unit)} #{ingredient.name}"
     end
+
+    return "#{display_name}: #{ingredient.preparation_style}" if ingredient.preparation_style.present?
+
+    display_name
   end
 
   def detail_display(detail)
-    ingredient = [
-      qty_display(detail),
-      detail.measurement_unit,
-      detail.preparation_style,
-      "(#{detail.recipe.title})",
-    ].join(' ')
+    pluralized = if Ingredient::DESCRIPTIVE_UNITS.include?(detail.measurement_unit)
+      "#{qty_display(detail)} #{detail.measurement_unit}"
+    else
+      pluralize(qty_display(detail), detail.measurement_unit)
+    end
 
-    link_to ingredient, recipe_path(detail.recipe)
+    [
+      pluralized,
+      detail.preparation_style.presence,
+    ].compact.join(' ')
   end
 
   def qty_display(ingredient)

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,16 +4,7 @@ class Ingredient < ApplicationRecord
   belongs_to :recipe, inverse_of: :ingredients
   before_save :format_name
 
-  # Units that do not get pluralized
-  DESCRIPTIVE_UNITS = %w[
-    small
-    medium
-    large
-    whole
-  ].freeze
-
-  # Standard units
-  UNITS = %w[
+  STANDARD_UNITS = %w[
     4oz\ can
     7oz\ can
     15oz\ can
@@ -40,7 +31,20 @@ class Ingredient < ApplicationRecord
     stick
     tablespoon
     teaspoon
-  ] + DESCRIPTIVE_UNITS
+  ].freeze
+
+  # Units that do not get pluralized
+  DESCRIPTIVE_UNITS = %w[
+    small
+    medium
+    large
+    whole
+  ].freeze
+
+  UNITS = [
+    STANDARD_UNITS,
+    DESCRIPTIVE_UNITS,
+  ].flatten.sort
 
   STYLES = %w[
     \
@@ -71,22 +75,6 @@ class Ingredient < ApplicationRecord
     uncooked
   ].freeze
 
-  # KNOWN_FOODS = %w[
-  #   agave\ nectar
-  #   apple\ cider\ vinegar
-  #   coconut\ oil
-  #   fresh\ ginger
-  #   garlic
-  #   green\ bell\ pepper
-  #   green\ onions
-  #   honey
-  #   lime
-  #   olive\ oil
-  #   onion
-  #   red\ bell\ pepper
-  #   toasted\ sesame \oil
-  # ].freeze
-
   validates :name,
             :quantity,
             :measurement_unit,
@@ -94,7 +82,6 @@ class Ingredient < ApplicationRecord
 
   validates :quantity, numericality: true
   validates :measurement_unit, inclusion: { in: UNITS }
-  # validates :preparation_style, inclusion: { in: STYLES }, if: -> { preparation_style.present? }
 
   def self.by_id
     order(:id)
@@ -107,31 +94,4 @@ class Ingredient < ApplicationRecord
   def measurement_and_name
     "#{measurement_unit} #{name}"
   end
-
-  # def to_shopping_list_item
-  #   ShoppingListItem.new(
-  #     quantity: self.quantity,
-  #     name: "#{self.measurement_unit} #{self.name}"
-  #   )
-  # end
-
-  # def convert_to_food
-  #   'WIP'
-  # end
-
-  # def self.parse(list)
-  #   %Q(
-  #     1/2 cup olive oil
-  #     1 red bell pepper, seeded and chopped into big pieces
-  #     2 tablespoons apple cider vinegar
-  #     1 lime, juiced
-  #     2 tablespoons agave nectar
-  #     3/4 inch piece of fresh ginger, peeled and roughly chopped
-  #     1 clove garlic
-  #     totally optional: 1/4 teaspoon toasted sesame oil
-  #   ).split("\n").map(&:strip)
-  # end
-
-  # def to_float
-  # end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,6 +4,15 @@ class Ingredient < ApplicationRecord
   belongs_to :recipe, inverse_of: :ingredients
   before_save :format_name
 
+  # Units that do not get pluralized
+  DESCRIPTIVE_UNITS = %w[
+    small
+    medium
+    large
+    whole
+  ].freeze
+
+  # Standard units
   UNITS = %w[
     4oz\ can
     7oz\ can
@@ -19,23 +28,19 @@ class Ingredient < ApplicationRecord
     head
     inch
     jar
-    large
     lb
     leaf
     loaf
-    medium
     quart
     ounce
     pint
     slice
-    small
     sprig
     stalk
     stick
     tablespoon
     teaspoon
-    whole
-  ].freeze
+  ] + DESCRIPTIVE_UNITS
 
   STYLES = %w[
     \

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -43,6 +43,7 @@
       <% details.each do |detail| %>
       <li>
         <%= detail_display(detail) %>
+        (<%= link_to detail.recipe.title, detail.recipe %>)
         <%= link_to '',
                     shopping_list_item_builders_path(
                       shopping_list_id: current_user.shopping_lists.default&.id,

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -6,6 +6,5 @@ FactoryBot.define do
     sequence(:name) { |n| "ingredient name #{n}" }
     quantity { 1.5 }
     measurement_unit { Ingredient::UNITS[1..-1].sample }
-    preparation_style { Ingredient::STYLES[1..-1].sample }
   end
 end

--- a/spec/helpers/ingredients_helper_spec.rb
+++ b/spec/helpers/ingredients_helper_spec.rb
@@ -5,25 +5,92 @@ require 'rails_helper'
 RSpec.describe IngredientsHelper, type: :helper do
   describe 'ingredient_display' do
     it "displays an ingredient's qty unit and name" do
-      ingredient = build(:ingredient, preparation_style: nil)
-      display_output = "#{ingredient.quantity} #{ingredient.measurement_unit} #{ingredient.name}"
-      expect(helper.ingredient_display(ingredient)).to eq(display_output)
+      ingredient = build(:ingredient,
+                         measurement_unit: 'cup',
+                         quantity: 1,
+                         name: 'water')
+      expected_output = '1 cup water'
+      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+    end
+
+    it 'pluralizes the unit when it is a standard unit' do
+      ingredient = build(:ingredient,
+                         measurement_unit: 'cup',
+                         quantity: 2,
+                         name: 'water')
+      expected_output = '2 cups water'
+      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+    end
+
+    it 'pluralizes the name when the unit is a descriptive unit' do
+      ingredient = build(:ingredient,
+                         measurement_unit: 'whole',
+                         quantity: 2,
+                         name: 'carrot')
+      expected_output = '2 whole carrots'
+      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
 
     it 'if present, displays the preparation_style' do
-      ingredient = build(:ingredient, preparation_style: 'styled')
-      display_output = "#{ingredient.quantity} #{ingredient.measurement_unit} #{ingredient.name}: #{ingredient.preparation_style}"
-      expect(helper.ingredient_display(ingredient)).to eq(display_output)
+      ingredient = build(:ingredient,
+                         preparation_style: 'minced',
+                         measurement_unit: 'clove',
+                         quantity: 3,
+                         name: 'garlic')
+      expected_output = '3 cloves garlic: minced'
+      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
   end
 
   describe 'detail_display' do
-    it "displays an ingredient's qty, unit, prep style, and recipe" do
-      recipe = create(:recipe)
-      ingredient = build(:ingredient, quantity: 1, measurement_unit: 'cup', preparation_style: 'dry', recipe: recipe)
-      display_output = "<a href=\"/recipes/#{recipe.id}\">1 cup dry (#{recipe.title})</a>"
+    let(:recipe) { create(:recipe) }
 
-      expect(helper.detail_display(ingredient)).to eq(display_output)
+    it "displays an ingredient's qty and unit" do
+      ingredient = build(
+        :ingredient,
+        quantity: 1,
+        measurement_unit: 'cup',
+        recipe: recipe
+      )
+      expected_output = '1 cup'
+      expect(helper.detail_display(ingredient)).to eq(expected_output)
+    end
+
+    it 'includes prep style when present' do
+      ingredient = build(
+        :ingredient,
+        name: 'tomato',
+        quantity: 1,
+        measurement_unit: 'cup',
+        preparation_style: 'diced',
+        recipe: recipe
+      )
+      expected_output = '1 cup diced'
+      expect(helper.detail_display(ingredient)).to eq(expected_output)
+    end
+
+    describe 'pluralization' do
+      it 'pluralizes the unit when it is a standard unit' do
+        ingredient = build(
+          :ingredient,
+          measurement_unit: 'cup',
+          quantity: 2,
+          recipe: recipe
+        )
+        expected_output = '2 cups'
+        expect(helper.detail_display(ingredient)).to eq(expected_output)
+      end
+
+      it 'does not pluralizes the unit when the unit is a descriptive unit' do
+        ingredient = build(
+          :ingredient,
+          measurement_unit: 'whole',
+          quantity: 2,
+          recipe: recipe
+        )
+        expected_output = '2 whole'
+        expect(helper.detail_display(ingredient)).to eq(expected_output)
+      end
     end
   end
 


### PR DESCRIPTION
I thought it was time to make the ingredient display look smarter with pluralization. The tricky part is that sometimes we pluralize the measurement unit, like "3 **cups** water" but other times we pluralize the food name, like "3 medium **carrots**".  This PR handles that logic for the recipe show page and the meal plan show page.

## Screenshots
### Before
The recipe show page does not pluralize any part of the ingredient listing.
<img width="412" alt="Screen Shot 2022-11-02 at 6 55 19 PM" src="https://user-images.githubusercontent.com/8680712/199623908-91c16cf6-d990-4bc1-ae08-607df534c772.png">

The meal plan show page does not pluralize any part of the ingredient listing.
<img width="375" alt="Screen Shot 2022-11-02 at 6 57 35 PM" src="https://user-images.githubusercontent.com/8680712/199624352-ab9cd78e-58ea-4af6-a90b-b94f3c99fa45.png">


### After
The recipe show page pluralizes ingredients when there is a descriptive measurement unit, like "large" or "whole" and pluralizes the measurement unit for normal units like "cup" or "tablespoon".
<img width="427" alt="Screen Shot 2022-11-02 at 6 55 28 PM" src="https://user-images.githubusercontent.com/8680712/199623885-ee508264-297d-4857-b67c-a47ba6373357.png">

The meal plan show page pluralizes in the same pattern as the recipe show page. Also, the link to the recipe is now from only the recipe title text.
<img width="676" alt="Screen Shot 2022-11-02 at 6 57 05 PM" src="https://user-images.githubusercontent.com/8680712/199624332-e58db526-2224-4754-98e9-116bc1072ba2.png">


## Things Learned
* View helpers are ugly. This PR has some repeated logic and it looks clunky, but I think it is okay for now.
* Making small pretty changes is very satisfying.

## Due Diligence Checks
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
