### PR TITLE
Add Procfile for production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Adds Procfile for production as per Heroku's recommendations

## Resources
https://devcenter.heroku.com/articles/procfile
https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server

## Things Learned
* WEBrick is the default server unless other Rails configurations have determined otherwise.
* It is better to be explicit. 
* Puma is the recommend server.

## Due Diligence Checks
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
