### PR TITLE
Add existing items to supplement browser autofill

### DIFF
--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -11,7 +11,13 @@
 <article class='index-item'>
   <%= form_tag(search_shopping_list_path(@shopping_list), method: 'get', id: 'search-form' ) do %>
     <div class="col-xs-12">
-      <%= text_field_tag :search, params[:search], placeholder: 'Find or Add an item...', class: 'form-control form-control-sm' %>
+      <%= text_field_tag :search, params[:search], list: 'name', placeholder: 'Find or Add an item...', class: 'form-control form-control-sm' %>
+      <datalist id="name">
+        <option value="  "></option>
+        <% @shopping_list.items.each do |item| %>
+          <option id="<%= item.id %>" value="<%= item.name %>"></option>
+        <% end %>
+      </datalist>
     </div>
   <% end %>
 </article>


### PR DESCRIPTION
The adding of items to the grocery list is not seamless. It takes two steps every time. It would be nice to fix this. This PR does not fix it. However, it does make selecting an existing item a little bit easier by preloading them into a `<datalist>` for the input field. Ideally, you'd just touch the item you want to add and be done with it, but we're not there yet. This is still an improvement because it lessens the keystrokes needed on mobile.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
