### PR TITLE
Hot fix: Convert to_s to to_fs

### DIFF
--- a/app/controllers/meal_plan_recipes_controller.rb
+++ b/app/controllers/meal_plan_recipes_controller.rb
@@ -9,10 +9,10 @@ class MealPlanRecipesController < ApplicationController
     if meal_plan_recipe.save
       redirect_back(
         fallback_location: recipes_url,
-        notice: "#{@recipe.title} added to #{@meal_plan.prepared_on.to_s(:short)} meal plan"
+        notice: "#{@recipe.title} added to #{@meal_plan.prepared_on.to_fs(:short)} meal plan"
       )
     else
-      flash[:error] = "#{@recipe.title} was already part of the #{@meal_plan.prepared_on.to_s(:short)} meal plan."
+      flash[:error] = "#{@recipe.title} was already part of the #{@meal_plan.prepared_on.to_fs(:short)} meal plan."
       redirect_back(fallback_location: recipes_url)
     end
   end

--- a/app/controllers/scheduled_deliveries_controller.rb
+++ b/app/controllers/scheduled_deliveries_controller.rb
@@ -38,7 +38,7 @@ class ScheduledDeliveriesController < ApplicationController
     # authorize(scheduled_delivery)
 
     scheduled_delivery.destroy
-    flash[:success] = "Your #{@scheduled_delivery.scheduled_for.to_s(:timestamp)} delivery was deleted."
+    flash[:success] = "Your #{@scheduled_delivery.scheduled_for.to_fs(:timestamp)} delivery was deleted."
     redirect_to @scheduled_delivery.shopping_list
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
 
   def display_link_to_plan
     upcoming = current_user.meal_plans.upcoming
-    link_to "Meal Plan: #{upcoming.prepared_on.to_s(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
+    link_to "Meal Plan: #{upcoming.prepared_on.to_fs(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
   end
 
   def display_list_and_count

--- a/app/views/scheduled_deliveries/edit.html.erb
+++ b/app/views/scheduled_deliveries/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1>
   <%= link_to "", shopping_list_path(@scheduled_delivery.shopping_list), class: Icon.back %>
-  Editing <%= @scheduled_delivery.scheduled_for.to_s(:timestamp) %>
+  Editing <%= @scheduled_delivery.scheduled_for.to_fs(:timestamp) %>
 </h1>
 
 <%= render 'form', scheduled_delivery: @scheduled_delivery, shopping_list: @shopping_list %>


### PR DESCRIPTION
Got some sentry errrors tonight:

https://anne-richardson.sentry.io/issues/4071035180/?referrer=alert_email&alert_type=email&alert_timestamp=1680911609420&alert_rule_id=1078349&environment=production&ref_fallback=ga

sentry error:
```
ArgumentError: wrong number of arguments (given 1, expected 0)
  app/helpers/application_helper.rb:31:in `to_s'
    link_to "Meal Plan: #{upcoming.prepared_on.to_s(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
  app/helpers/application_helper.rb:31:in `display_link_to_plan'
    link_to "Meal Plan: #{upcoming.prepared_on.to_s(:short)}", meal_plan_path(upcoming), class: 'nav-link' if upcoming
  app/views/shared/navbar/_signed_in.html.erb:15:
    <%= display_link_to_plan %>
  app/views/shared/navbar/_main.html.erb:9:
    <%= render 'shared/navbar/signed_in' if current_user %>
  app/views/layouts/application.html.erb:26:
    <%= render 'shared/navbar/main' %>

```

