### PR TITLE
Make extra work note more visible on show pages

### DIFF
--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -21,7 +21,7 @@ module RecipesHelper
   def extra_work_flag(recipe)
     return unless recipe.extra_work_required?
 
-    "<i class=\"#{Icon.clock}\", title=\"Heads Up! #{recipe.extra_work_note}\"></i>".html_safe
+    "<i class=\"#{Icon.clock} fa-xs\", title=\"Heads Up! #{recipe.extra_work_note}\"></i>".html_safe
   end
 
   def recipe_ingredient_ids(recipe)

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -14,8 +14,12 @@
       <li>Estimated Prep Duration: <%= display_time(@meal_plan.estimated_time) %></li>
       <li>Recommended Start Time: <%= @meal_plan.recommended_start_time %></li>
       <li>Total Ingredients: <%= @meal_plan.total_unique_ingredients %></li>
-      <% if @meal_plan.notes.present? %><li>Notes: <%= @meal_plan.notes %></li><% end %>
     </ul>
+
+    <% if @meal_plan.notes.present? %>
+      <h2>Notes</h2>
+      <p><%= @meal_plan.notes %></p>
+    <% end %>
   </section>
 
   <section class="col-12 col-sm-6">

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-11">
-    <h1><%= @recipe.title %> <small><%= extra_work_flag(@recipe) if current_user.present? %></small></h1>
+    <h1><%= @recipe.title %><sup><%= extra_work_flag(@recipe) if current_user.present? %></sup></h1>
     <p>
       Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank' %>
     </p>
@@ -24,10 +24,10 @@
           <li>Total Time: <%= display_time(@recipe.total_time) %></li>
           <li>Reheat Time: <%= display_time(@recipe.reheat_time) %></li>
           <li>Prepared: <%= pluralize(@recipe.frequency, 'time') %></li>
-          <% if @recipe.extra_work_required? %>
-            <li>Extra Work Warning: <%= @recipe.extra_work_note %></li>
-          <% end %>
         </ul>
+        <% if @recipe.extra_work_required? %>
+          <p><%= extra_work_flag(@recipe) %> <strong>Heads up!</strong> <%= @recipe.extra_work_note %></p>
+        <% end %>
       </div> <!-- col-6 -->
 
       <div class='col-md-6 col-sm-12'>


### PR DESCRIPTION
## Problems Solved
I found that any notes I was writing in the Meal Plan notes weren't very visible. They seemed like an afterthought on the page when they're actually pretty important to pay attention to on food prep day. Same goes for the extra work note on the recipe show page. This PR makes both of those pieces of information easier to notice by breaking them out of the bulleted lists they were in and giving them their own sections.

## Screenshots
| Page | Before | After |
|----|----|---|
| Recipe show page | <img width="722" alt="Screen Shot 2023-09-18 at 6 45 00 PM" src="https://github.com/lortza/food_planner/assets/8680712/db48c586-0c65-4082-9042-c4e755d10912"> | <img width="753" alt="Screen Shot 2023-09-18 at 6 41 31 PM" src="https://github.com/lortza/food_planner/assets/8680712/96ea9f57-1dde-4276-b2e4-aa285d9be53d"> |
| Meal Plan show page | <img width="1067" alt="Screen Shot 2023-09-18 at 6 44 52 PM" src="https://github.com/lortza/food_planner/assets/8680712/3833fc59-242a-49e8-8174-ef8051f2faa9"> | <img width="1091" alt="Screen Shot 2023-09-18 at 6 41 52 PM" src="https://github.com/lortza/food_planner/assets/8680712/804d0087-742c-4e30-9fb7-f0cf70f0efc0"> |


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] ~I have written new specs for this work~ design changes only
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
