### PR TITLE
Move notes up

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -1,131 +1,128 @@
 <div class="recipe-form">
   <%= form_for(recipe) do |form| %>
-  <%= render 'shared/errors', object: recipe %>
+    <%= render 'shared/errors', object: recipe %>
 
-  <%= hidden_field(:recipe, :experimental_recipe_id )  %>
+    <%= hidden_field(:recipe, :experimental_recipe_id )  %>
 
-  <div class="row">
-    <div class="col">
-      <div class="field">
-        <%= form.label :title %>
-        <%= form.text_field :title, autofocus: true, class: 'form-control' %>
+    <div class="row">
+      <div class="col">
+        <div class="field">
+          <%= form.label :title %>
+          <%= form.text_field :title, autofocus: true, class: 'form-control' %>
+        </div>
+      </div>
+    </div> <!-- row -->
+
+    <div class="row">
+      <div class="field col-sm">
+        <%= form.label :source_name %>
+        <%= form.text_field :source_name, class: 'form-control' %>
+      </div>
+
+      <div class="field col-sm">
+        <%= form.label :source_url %>
+        <%= form.text_field :source_url, class: 'form-control' %>
       </div>
     </div>
-  </div> <!-- row -->
 
-  <div class="row">
-    <div class="field col-sm">
-      <%= form.label :source_name %>
-      <%= form.text_field :source_name, class: 'form-control' %>
-    </div>
-
-    <div class="field col-sm">
-      <%= form.label :source_url %>
-      <%= form.text_field :source_url, class: 'form-control' %>
-    </div>
-  </div>
-
-  <div class="field">
-    <%= form.label :image_url %>
-    <%= form.text_field :image_url, class: 'form-control' %>
-  </div>
-
-  <div class="row">
-    <div class="field col-sm">
-      <%= form.label :servings %>
-      <%= form.number_field :servings, class: 'form-control' %>
-    </div>
-
-    <div class="field col-sm">
-      <%= form.label 'Prep Time (min)' %>
-      <%= form.number_field :prep_time, class: 'form-control' %>
-    </div>
-
-    <div class="field col-sm">
-      <%= form.label 'Cook Time (min)' %>
-      <%= form.number_field :cook_time, class: 'form-control' %>
-    </div>
-
-    <div class="field col-sm">
-      <%= form.label 'Reheat Time (min)' %>
-      <%= form.number_field :reheat_time, class: 'form-control' %>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-sm-12">
-      <div class="field">
-        <%= form.label :extra_work_note %>
-        <%= form.text_field :extra_work_note, class: 'form-control' %>
-      </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-sm-12">
-      <div class="field">
-        <%= form.label 'Cronometer iframe' %>
-        <%= form.text_area :nutrition_data_iframe, class: 'form-control' %>
-      </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-sm-10">
-      <div class="field">
-        <%= form.label :notes %>
-        <%= form.text_area :notes, class: 'form-control' %>
-      </div>
-    </div>
-    <div class="col-sm-2">
-      <div class="field">
-        <%= form.label :archived %>
-        <%= form.check_box :archived, class: 'form-control' %>
-      </div>
-    </div>
-  </div> <!-- row -->
-
-  <table class="table table-ingredients">
-    <thead>
-      <tr>
-        <th>Qty</th>
-        <th>Measurement</th>
-        <th>Name</th>
-        <th>Preparation Style</th>
-        <th>Delete?</th>
-      </tr>
-    </thead>
-    <tbody>
-      <%= form.fields_for :ingredients do |f_ingredient| %>
-      <tr>
-        <%= render 'ingredients/form_fields', f_ingredient: f_ingredient %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<div class="field">
-  <%= form.label 'Instructions' %>
-  <%= form.text_area :instructions, class: 'form-control instructions' %>
-</div>
-
-<div class="row">
-  <div class="col-lg-6 col-md-12">
     <div class="field">
-      <%= form.label 'Prep Day Instructions' %>
-      <%= form.text_area :prep_day_instructions, class: 'form-control instructions' %>
+      <%= form.label :image_url %>
+      <%= form.text_field :image_url, class: 'form-control' %>
     </div>
-  </div>
 
-  <div class="col-lg-6 col-md-12">
+    <div class="row">
+      <div class="field col-sm">
+        <%= form.label :servings %>
+        <%= form.number_field :servings, class: 'form-control' %>
+      </div>
+
+      <div class="field col-sm">
+        <%= form.label 'Prep Time (min)' %>
+        <%= form.number_field :prep_time, class: 'form-control' %>
+      </div>
+
+      <div class="field col-sm">
+        <%= form.label 'Cook Time (min)' %>
+        <%= form.number_field :cook_time, class: 'form-control' %>
+      </div>
+
+      <div class="field col-sm">
+        <%= form.label 'Reheat Time (min)' %>
+        <%= form.number_field :reheat_time, class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="field">
+          <%= form.label :extra_work_note %>
+          <%= form.text_field :extra_work_note, class: 'form-control' %>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="field">
+          <%= form.label 'Cronometer iframe' %>
+          <%= form.text_area :nutrition_data_iframe, class: 'form-control' %>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-10">
+        <div class="field">
+          <%= form.label :notes %>
+          <%= form.text_area :notes, class: 'form-control' %>
+        </div>
+      </div>
+      <div class="col-sm-2">
+        <div class="field">
+          <%= form.label :archived %>
+          <%= form.check_box :archived, class: 'form-control' %>
+        </div>
+      </div>
+    </div> <!-- row -->
+
+    <table class="table table-ingredients">
+      <thead>
+        <tr>
+          <th>Qty</th>
+          <th>Measurement</th>
+          <th>Name</th>
+          <th>Preparation Style</th>
+          <th>Delete?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= form.fields_for :ingredients do |f_ingredient| %>
+          <tr><%= render 'ingredients/form_fields', f_ingredient: f_ingredient %></tr>
+        <% end %>
+      </tbody>
+    </table>
+
     <div class="field">
-      <%= form.label :reheat_instructions %>
-      <%= form.text_area :reheat_instructions, class: 'form-control instructions' %>
+      <%= form.label 'Instructions' %>
+      <%= form.text_area :instructions, class: 'form-control instructions' %>
     </div>
-  </div>
-</div><!-- row -->
 
-<%= form.submit class: button_classes('primary mt-3') %>
+    <div class="row">
+      <div class="col-lg-6 col-md-12">
+        <div class="field">
+          <%= form.label 'Prep Day Instructions' %>
+          <%= form.text_area :prep_day_instructions, class: 'form-control instructions' %>
+        </div>
+      </div>
 
-<% end %>
+      <div class="col-lg-6 col-md-12">
+        <div class="field">
+          <%= form.label :reheat_instructions %>
+          <%= form.text_area :reheat_instructions, class: 'form-control instructions' %>
+        </div>
+      </div>
+    </div><!-- row -->
+
+    <%= form.submit class: button_classes('primary mt-3') %>
+  <% end %>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -25,17 +25,18 @@
           <li>Reheat Time: <%= display_time(@recipe.reheat_time) %></li>
           <li>Prepared: <%= pluralize(@recipe.frequency, 'time') %></li>
         </ul>
-        <% if @recipe.extra_work_required? %>
-          <p><%= extra_work_flag(@recipe) %> <strong>Heads up!</strong> <%= @recipe.extra_work_note %></p>
-        <% end %>
       </div> <!-- col-6 -->
 
       <div class='col-md-6 col-sm-12'>
-        <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} if policy(@recipe).update? %>
+        <% if @recipe.extra_work_required? %>
+            <p class='alert alert-warning'><strong>Heads up!</strong> <%= @recipe.extra_work_note %></p>
+        <% end %>
+        <% if @recipe.notes.present? %>
+          <h5>Notes</h5>
+          <p><%= @recipe.notes %></p>
+        <% end %>
       </div> <!-- col-6 -->
     </div> <!-- row -->
-
-    <p><%= @recipe.notes %></p>
 
     <div class='row'>
       <div class='col-12'>
@@ -52,12 +53,12 @@
 
   <div class='col-md-4 col-sm-12'>
     <div class='image-container mb-3'>
-      <%#= image_tag @recipe.image_url, { class: 'image' } %>
       <%= image_tag guaranteed_image(@recipe), { class: 'image' } %>
-
     </div>
+
     <% if policy(@recipe).update? %>
       <%= render partial: 'shared/add_to_shopping_list_dropdown', locals: { ingredient_ids: recipe_ingredient_ids(@recipe) } %>
+      <%= render partial: 'related_meal_plans', locals: {recipe: @recipe} %>
       <%= render partial: 'copy_for_user_form', locals: { recipe: @recipe } %>
       <%= render partial: 'related_recipes', locals: {recipe: @recipe} %>
     <% end %>


### PR DESCRIPTION
## Related Issues & PRs
Closes #744 

## Problems Solved
* The notes section hiding on mobile
* moved the related meal plans off to the right sidebar since it is not crucial info
* "heads up" note is now more visible

## Screenshots

|  Before | After | 
|-----|-----|
| under related meal plans | right after heads up note |
| heads up note is small | heads up note is own alert box |
| <img width="448" alt="Screen Shot 2023-10-02 at 7 02 18 PM" src="https://github.com/lortza/food_planner/assets/8680712/d0083f4a-bf74-48db-8b54-cc8e9b6bc1be"> | <img width="448" alt="Screen Shot 2023-10-02 at 7 02 36 PM" src="https://github.com/lortza/food_planner/assets/8680712/1ff5aacc-39e1-4be7-b1e8-02c158888d61"> |

After: full screen size
<img width="800" alt="Screen Shot 2023-10-02 at 7 02 18 PM" src="https://github.com/lortza/food_planner/assets/8680712/618940d1-20fc-4666-a255-61b79e5311f1">


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
