### PR TITLE
Remove aisle when empty

### DIFF
--- a/app/assets/stylesheets/shopping_lists.scss
+++ b/app/assets/stylesheets/shopping_lists.scss
@@ -3,10 +3,11 @@
 .aisle {
   background-color: $brand-secondary;
   color: $white;
-  font-size: .75rem;
+  font-size: .8rem;
   font-weight: normal;
   margin-bottom: 0;
   padding: 5px 8px;
+  text-transform: uppercase;
 }
 
 .recurrence-tag {

--- a/app/controllers/shopping_list_item_statuses_controller.rb
+++ b/app/controllers/shopping_list_item_statuses_controller.rb
@@ -21,6 +21,7 @@ class ShoppingListItemStatusesController < ApplicationController
   def deactivate
     # crosses an item off of the list
     @shopping_list_item.deactivate!
+    @remove_aisle = @shopping_list_item.list.items.active.where(aisle: @shopping_list_item.aisle).blank?
     respond_to :js
   end
 

--- a/app/views/shopping_list_item_statuses/deactivate.js.erb
+++ b/app/views/shopping_list_item_statuses/deactivate.js.erb
@@ -1,7 +1,8 @@
-// TODO: when aisle is empty, remove aisle heading
-
-document.getElementById("<%= dom_id(@shopping_list_item) %>")
-        .remove();
+if (<%= @remove_aisle %>) {
+  document.getElementById("<%= dom_id(@shopping_list_item.aisle) %>").remove();
+} else {
+  document.getElementById("<%= dom_id(@shopping_list_item) %>").remove();
+}
 
 document.getElementById('js-inactive-items')
         .insertAdjacentHTML('afterbegin', "<%= escape_javascript(render partial: '/shopping_list_items/shopping_list_item', locals: { item: @shopping_list_item }) %>");

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -29,12 +29,14 @@
 <section id='js-active-items'>
   <% @shopping_list.shopping_list_items.not_purchased.by_aisle_order_number.group_by(&:aisle).each do |aisle, items| %>
     <% if aisle %>
-      <h4 class='aisle'><%= aisle.name %></h4>
-      <% items.each do |item| %>
-        <%= render partial: '/shopping_list_items/shopping_list_item', locals: { item: item } %>
-      <% end %><!-- each -->
+      <div id='<%= dom_id(aisle) %>'>
+        <h4 class='aisle'><%= aisle.name %></h4>
+        <% items.each do |item| %>
+          <%= render partial: '/shopping_list_items/shopping_list_item', locals: { item: item } %>
+        <% end %><!-- each -->
+      </div>
     <% end %><!-- if aisle -->
-  <% end %>
+  <% end %><!-- each -->
 </section>
 
 <h4 class='aisle'>Crossed Off</h4>


### PR DESCRIPTION
## Related Issues & PRs
Closes #762

## Problems Solved
When crossing items off of a shopping list, when you cross off the last item of an aisle, the aisle header stays on the list. This is weird looking. This PR removes the aisle when the last item is crossed off. 

This PR does not do the work of reinstating the aisle upon reactivating an item (clicking an item that is crossed off to put ut back on the list).

I also made the aisle headers a little bigger looking for better visibility on mobile while shopping:
| before | after |
|----|----|
| <img width="379" alt="Screen Shot 2023-10-18 at 8 19 09 AM" src="https://github.com/lortza/food_planner/assets/8680712/6164db7a-98fc-4f47-a28c-8b330f86f590"> | <img width="382" alt="Screen Shot 2023-10-18 at 8 17 42 AM" src="https://github.com/lortza/food_planner/assets/8680712/720088d7-8d42-44d0-8848-48c5d8d7f10e"> |



## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
