### PR TITLE
Handle null aisle when reinstating shopping list items

### DIFF
--- a/app/views/shopping_list_item_statuses/activate.js.erb
+++ b/app/views/shopping_list_item_statuses/activate.js.erb
@@ -3,5 +3,9 @@ document.getElementById("<%= dom_id(@shopping_list_item) %>").remove();
 
 // Reinstate item as active in aisle
 var aisle = document.getElementById("<%= dom_id(@shopping_list_item.aisle) %>")
-aisle.classList.remove('hidden');
-aisle.insertAdjacentHTML('beforeend', "<%= escape_javascript(render partial: '/shopping_list_items/shopping_list_item', locals: { item: @shopping_list_item }) %>");
+if (aisle === null ) {
+  document.getElementById('js-active-items').insertAdjacentHTML('beforeend', "<%= escape_javascript(render partial: '/shopping_list_items/shopping_list_item', locals: { item: @shopping_list_item }) %>");
+} else {
+  aisle.classList.remove('hidden');
+  aisle.insertAdjacentHTML('beforeend', "<%= escape_javascript(render partial: '/shopping_list_items/shopping_list_item', locals: { item: @shopping_list_item }) %>");
+}


### PR DESCRIPTION
The sweet shopping list item reinstatement does not work on a freshly loaded page. If the aisle exists on that page load, you _can_ cross off an item and then put it back. BUT if you refresh the page and _then_ want to reinstate an item, it doesn't know where to go. This PR fixes that bug by appending the item to the active items section in the case that it can't find its aisle. 

I should probably have some capybara tests... 😆 