### PR TITLE
Fix shopping list item deactivate

### DIFF
--- a/app/views/shopping_list_item_statuses/deactivate.js.erb
+++ b/app/views/shopping_list_item_statuses/deactivate.js.erb
@@ -2,8 +2,9 @@
 document.getElementById("<%= dom_id(@shopping_list_item) %>").remove();
 
 // Hide aisle if this was the last item in it
-if (<%= @remove_aisle %>) {
-  document.getElementById("<%= dom_id(@shopping_list_item.aisle) %>").classList.add('hidden');
+var activeAisle = document.getElementById("<%= dom_id(@shopping_list_item.aisle) %>")
+if (<%= @remove_aisle %> && activeAisle != null) {
+  activeAisle.classList.add('hidden');
 }
 
 // Prepend item to crossed-off section


### PR DESCRIPTION
## Problems Solved
On a fresh page load, a deactivated item does not have a hidden aisle in the DOM. When reactivating an item that does not have an aisle and then deactivating it again, the JS fails because it assumes the presence of the aisle before trying to hide it. This results in the newly deactivated item not being inserted in the inactive section. This PR no longer assumes the aisle's presence, which allows the JS to continue and the item to be inserted in the inactive section.
