### PR TITLE
Update badges on list search and recipe show heading

### DIFF
--- a/app/components/material_icon.rb
+++ b/app/components/material_icon.rb
@@ -14,6 +14,7 @@ class MaterialIcon
   def render
     case @icon
     when :add_shopping_cart then add_shopping_cart;
+    when :archived then archived;
     when :arrow_left then arrow_left;
     when :calendar_clock then calendar_clock;
     when :checkmark then checkmark;
@@ -51,6 +52,12 @@ class MaterialIcon
     content_tag(:span, 'arrow_back',
       class: "#{symbol_base_classes} #{@classes} nav-link-icon left",
       title: @title.presence || 'Back')
+  end
+
+  def archived
+    content_tag(:span, 'inventory_2',
+      class: "#{symbol_base_classes} #{@classes}",
+      title: @title.presence || 'Archived')
   end
 
   def calendar_clock

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -8,7 +8,11 @@ module RecipesHelper
 
   def status_flag(recipe)
     if !recipe.active?
-      'archived'
+      icon = MaterialIcon.new(icon: :archived, size: :small).render
+      content_tag(:span, "Archived",
+        class: "badge badge-secondary ml-2 text-small font-weight-normal cursor-default",
+        title: 'Recipe is archived. Edit to unarchive.'
+      ) {icon + " Archived"}
     elsif recipe.last_prepared.nil? || first_time_is_this_week?(recipe)
       MaterialIcon.new(icon: :new, classes: 'text-warning cursor-default', title: 'New! Has not been made yet').render
     elsif recipe.last_prepared < Time.zone.today.prev_month(4)

--- a/app/views/shopping_list_item_statuses/activate_from_search.js.erb
+++ b/app/views/shopping_list_item_statuses/activate_from_search.js.erb
@@ -1,5 +1,6 @@
-let selectedItem = document.getElementById("<%= dom_id(@shopping_list_item) %>").getElementsByTagName('a')[0];
+let selectedItem = document.getElementById("<%= dom_id(@shopping_list_item) %>").querySelector('.js-item-content')
 
 let checkmark = "<%= escape_javascript(MaterialIcon.new(icon: :checkmark).render) %>"
 let badge = `<span class="badge badge-success ml-2">${checkmark} Added to list</span>`
-selectedItem.insertAdjacentHTML('afterend', badge)
+
+selectedItem.insertAdjacentHTML('beforeend', badge)

--- a/app/views/shopping_list_items/_shopping_list_item.erb
+++ b/app/views/shopping_list_items/_shopping_list_item.erb
@@ -1,6 +1,6 @@
 <article id='<%= dom_id(item) %>' class='shopping-list-item'>
   <div class='controls-on-right-parent'>
-    <span>
+    <span class='js-item-content'>
       <!-- local_assigns handles whether the local arg has been passed to the partial.
       This allows the partial to be used by the normal shopping list functions as well
       as the search function. The reason I'm not passing a destination_path every time

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RecipesHelper, type: :helper do
   describe 'status_flag' do
     it 'returns "archived" when recipe is not active' do
       recipe = build(:recipe, archived: true)
-      expect(helper.status_flag(recipe)).to eq('archived')
+      expect(helper.status_flag(recipe)).to include('Archived')
     end
 
     it 'returns "new" when recipe has no prep dates' do


### PR DESCRIPTION
## Problems Solved
This PR does a little more tweaking to some recent changes. 
* Update location of confirmation badge after item is added to shopping list
* Replace "archived" status indicator with badge

## Screenshots
| Before | After |
|-----|----|
| <img width="741" alt="Screen Shot 2023-10-21 at 10 53 28 AM" src="https://github.com/lortza/food_planner/assets/8680712/293cc742-b977-44f1-a3d8-e033fa626d87"> | <img width="745" alt="Screen Shot 2023-10-21 at 10 51 07 AM" src="https://github.com/lortza/food_planner/assets/8680712/79745278-56a3-4dce-bd31-74f190083682"> |
| <img width="722" alt="Screen Shot 2023-10-21 at 11 22 58 AM" src="https://github.com/lortza/food_planner/assets/8680712/56f2bd1d-b7ef-430f-9794-f3597b54da76"> | <img width="719" alt="Screen Shot 2023-10-21 at 11 22 40 AM" src="https://github.com/lortza/food_planner/assets/8680712/d89600bb-5562-42a0-af81-fb24a0366da2"> |

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
