### PR TITLE
Add wip ingredient scraper

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -69,7 +69,8 @@ class RecipesController < ApplicationController
       title: experimental_recipe.title,
       source_name: URI.parse(experimental_recipe.source_url).host.gsub('www.', ''),
       source_url: experimental_recipe.source_url,
-      experimental_recipe_id: experimental_recipe.id
+      experimental_recipe_id: experimental_recipe.id,
+      instructions: Scraper.new(experimental_recipe.source_url).site_data
     )
     15.times { @recipe.ingredients.build(quantity: nil) }
 

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# https://www.zenrows.com/blog/web-scraping-ruby#extract-data
+# https://www.scrapingbee.com/blog/web-scraping-ruby/
+
+class Scraper
+  require 'open-uri'
+  # require 'net/http'
+  # require 'json'
+
+  # html = URI.open("https://en.wikipedia.org/wiki/Douglas_Adams")
+
+  attr_reader :site_data
+
+  def initialize(endpoint)
+    @endpoint = endpoint
+    @site_data = scrape_site
+  end
+
+  private
+
+  def scrape_site
+    # @client = Net::HTTP.new(@endpoint)
+    # @client.initialize_http_header({'User-Agent' => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" })
+    # response = @client.request_get(@endpoint)
+    # JSON.parse(response)
+    html = URI.open(@endpoint)
+    doc = Nokogiri::HTML(html)
+    items = doc.css("li").filter_map { |li| li.text.squish unless li.text.blank? }
+    items.join("\n")
+
+    # lis = doc.css('li')
+    # ingredient_heading = doc.at('h2:contains("Ingredients")') || doc.at('h3:contains("Ingredients")') || doc.at('h4:contains("Ingredients")')
+    # instructions_heading = doc.at('h2:contains("Instructions")') || doc.at('h3:contains("Instructions")') || doc.at('h4:contains("Instructions")')
+
+    # doc.xpath("//h3[text()='Ingredients']/following-sibling::ul/li").each do |node|
+    #   puts node.to_html
+    # end
+  end
+end


### PR DESCRIPTION
## Problems Solved
This PR adds a super duper teeny tiny scraping helper to the "convert from experimental" workflow for recipes. Manually entering recipe ingredients and instructions isn't easy, but neither is scraping sites. This PR takes the first step in implementing some basic scraping to help make that process is a little bit easier. 

Essentially, it grabs all of the `<li>`s on a recipe site and dumps them in a big list in the `instructions` field of a new recipe. The user still has to manually enter the ingredients and delete all of the extraneous garbage that comes in as `<li>` content. This is a small step better than a direct copy/paste.

In the future, I may try to get the data more accurately. I may also want to implement a "new from url" workflow. I'll just use this for now to see how it goes.