### PR TITLE
Make grocery list home page

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ShoppingListsController < ApplicationController
-  before_action :set_shopping_list, only: %i[show search edit update destroy]
+  before_action :set_shopping_list, only: %i[search edit update destroy]
 
   def index
     @shopping_lists = current_user.shopping_lists.search(field: 'name', terms: params[:search]).by_favorite.by_name
@@ -9,6 +9,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def show
+    set_shopping_list_for_root
     authorize(@shopping_list)
 
     @shopping_list_item = @shopping_list.shopping_list_items.new(quantity: 1)
@@ -61,6 +62,10 @@ class ShoppingListsController < ApplicationController
   end
 
   private
+
+  def set_shopping_list_for_root
+    @shopping_list = ShoppingList.find_by(id: params[:id]) || current_user.shopping_lists.by_favorite.first || current_user.shopping_lists.default
+  end
 
   def set_shopping_list
     @shopping_list = ShoppingList.find(params[:id])

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -21,6 +21,10 @@ class ShoppingList < ApplicationRecord
     order(favorite: :desc)
   end
 
+  def default?
+    main == true
+  end
+
   def deletable?
     main == false
   end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -34,7 +34,7 @@ class ShoppingListItem < ApplicationRecord
   end
 
   def self.by_aisle_order_number
-    includes(:aisle).order('aisles.order_number')
+    includes(:aisle).order('aisles.order_number ASC, shopping_list_items.name ASC')
   end
 
   def active?

--- a/app/policies/shopping_list_policy.rb
+++ b/app/policies/shopping_list_policy.rb
@@ -24,13 +24,13 @@ class ShoppingListPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_is_owner_of_record_or_admin?
+    user_is_owner_of_record_or_admin? && record.default? == false
   end
 
   private
 
   def user_is_owner_of_record_or_admin?
-    # only allow action to run if the current_user on their own recipe
+    # only allow action to run if the current_user on their own shopping_list
     (record.user_id == user&.id) || user&.admin?
   end
 end

--- a/app/views/shopping_lists/edit.html.erb
+++ b/app/views/shopping_lists/edit.html.erb
@@ -1,12 +1,19 @@
 <p><%= link_to MaterialIcon.new(icon: :arrow_left).render + 'Shopping Lists', shopping_lists_path %></p>
 
-<h1>Editing <%= @shopping_list.name %></h1>
+<h1>
+  Editing <%= @shopping_list.name %>
+  <% if @shopping_list.default? %>
+    (Default List)
+  <% end %>
+</h1>
 
-<%= link_to 'Clear List', deactivate_all_items_path(@shopping_list), method: :post, data: { confirm: 'Are you sure you want to cross off all items? This action cannot be undone.' }, title: 'clear list', class: "#{button_classes} mr-2" %>
+<%= link_to 'Cross off all items on list', deactivate_all_items_path(@shopping_list), method: :post, data: { confirm: 'Are you sure you want to cross off all items? This action cannot be undone.' }, title: 'clear list', class: "#{button_classes} mr-2" %>
 
 <hr>
 
 <%= render 'form', shopping_list: @shopping_list %>
 
-<%= render partial: 'shared/delete_footer', locals: { object: @shopping_list, delete_path: @shopping_list } %>
+<% if policy(@shopping_list).destroy? %>
+  <%= render partial: 'shared/delete_footer', locals: { object: @shopping_list, delete_path: @shopping_list } %>
+<% end %>
 

--- a/app/views/shopping_lists/index.html.erb
+++ b/app/views/shopping_lists/index.html.erb
@@ -7,18 +7,16 @@
 
 <% if current_user.shopping_lists.any? %>
   <% @shopping_lists.each do |shopping_list| %>
-      <p class='index-item controls-on-right-parent'>
-        <span>
-          <%= toggle_favorite(shopping_list) %>
-          <%= link_to shopping_list.name, shopping_list_path(shopping_list) %>
-          (<%= shopping_list.items.not_purchased.length %>)
-        </span>
-        <%  if shopping_list.deletable? %>
-          <span class='controls'>
-            <%= link_to MaterialIcon.new(icon: :settings, classes: 'float-right').render, edit_shopping_list_path(shopping_list) %>
-          </span>
-        <% end %>
-      </p>
+    <p class='index-item controls-on-right-parent'>
+      <span>
+        <%= toggle_favorite(shopping_list) %>
+        <%= link_to shopping_list.name, shopping_list_path(shopping_list) %>
+        (<%= shopping_list.items.not_purchased.length %>)
+      </span>
+      <span class='controls'>
+        <%= link_to MaterialIcon.new(icon: :settings, classes: 'float-right').render, edit_shopping_list_path(shopping_list) %>
+      </span>
+    </p>
   <% end %>
 
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  root 'recipes#index'
+  root 'shopping_lists#show'
 
   # Skip registrations for now so no new users can sign up.
   devise_for :users, skip: [:registrations]

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -88,16 +88,20 @@ RSpec.describe ShoppingListItem, type: :model do
   end
 
   describe 'self.by_aisle_order_number' do
-    it "orders based on the associated aisle's order_number" do
-      first_aisle = create(:aisle, name: 'first aisle', order_number: 1)
+    it "orders based on the associated aisle's order_number then by item name" do
       second_aisle = create(:aisle, name: 'second aisle', order_number: 2)
+      first_aisle = create(:aisle, name: 'first aisle', order_number: 1)
 
       list = create(:shopping_list, name: 'list')
-      second_item = create(:shopping_list_item, shopping_list_id: list.id, aisle_id: second_aisle.id)
-      first_item = create(:shopping_list_item, shopping_list_id: list.id, aisle_id: first_aisle.id)
+      third_item = create(:shopping_list_item, name: 'carrots', shopping_list_id: list.id, aisle_id: second_aisle.id)
+      second_item = create(:shopping_list_item, name: 'bananas', shopping_list_id: list.id, aisle_id: second_aisle.id)
+      first_item = create(:shopping_list_item, name: 'apples', shopping_list_id: list.id, aisle_id: first_aisle.id)
 
-      expect(list.shopping_list_items.by_aisle_order_number.first).to eq(first_item)
-      expect(list.shopping_list_items.by_aisle_order_number.last).to eq(second_item)
+      aggregate_failures("verifying item order") do
+        expect(list.shopping_list_items.by_aisle_order_number[0]).to eq(first_item)
+        expect(list.shopping_list_items.by_aisle_order_number[1]).to eq(second_item)
+        expect(list.shopping_list_items.by_aisle_order_number[2]).to eq(third_item)
+      end
     end
   end
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
+  describe 'default?' do
+    it 'returns true if it is the "main" list' do
+      list = build(:shopping_list, main: true)
+      expect(list.default?).to be(true)
+    end
+
+    it 'returns false if it is any other list' do
+      list = build(:shopping_list)
+      expect(list.default?).to be(false)
+    end
+  end
+
   describe 'deletable?' do
     it 'returns false if it is the "main" list' do
       list = build(:shopping_list, main: true)

--- a/spec/policies/shopping_list_policy_spec.rb
+++ b/spec/policies/shopping_list_policy_spec.rb
@@ -3,113 +3,154 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingListPolicy, type: :policy do
-  let(:user) { create(:user) }
-  let(:shopping_list) { create(:shopping_list, user: user) }
+  let(:author) { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+  let(:shopping_list) { create(:shopping_list, user: author) }
 
   subject { ShoppingListPolicy }
 
   permissions :show? do
-    it 'denies access to visitors' do
-      no_user = nil
-      expect(subject).not_to permit(no_user, shopping_list)
+    describe 'denies access to...' do
+      it 'visitors' do
+        no_user = nil
+        expect(subject).not_to permit(no_user, shopping_list)
+      end
+
+      it 'non-author users' do
+        different_user = create(:user)
+        expect(subject).not_to permit(different_user, shopping_list)
+      end
     end
 
-    it 'denies access to non-author users' do
-      different_user = create(:user)
-      expect(subject).not_to permit(different_user, shopping_list)
-    end
+    describe 'permits access to...' do
+      it 'author users' do
+        expect(subject).to permit(author, shopping_list)
+      end
 
-    it 'permits access to author users' do
-      expect(subject).to permit(user, shopping_list)
-    end
-
-    it 'permits access to non-author admin users' do
-      admin = create(:user, admin: true)
-      expect(subject).to permit(admin, shopping_list)
+      it 'non-author admin users' do
+        # admin = create(:user, admin: true)
+        expect(subject).to permit(admin, shopping_list)
+      end
     end
   end
 
   permissions :create? do
-    it 'denies access to visitors' do
-      no_user = nil
-      expect(subject).not_to permit(no_user, shopping_list)
+    describe 'denies access to...' do
+      it 'visitors' do
+        no_user = nil
+        expect(subject).not_to permit(no_user, shopping_list)
+      end
+
+      it 'non-author users' do
+        different_user = create(:user)
+        expect(subject).not_to permit(different_user, shopping_list)
+      end
     end
 
-    it 'denies access to non-author users' do
-      different_user = create(:user)
-      expect(subject).not_to permit(different_user, shopping_list)
-    end
+    describe 'permits access to...' do
+      it 'author users' do
+        expect(subject).to permit(author, shopping_list)
+      end
 
-    it 'permits access to author users' do
-      expect(subject).to permit(user, shopping_list)
-    end
-
-    it 'permits access to non-author admin users' do
-      admin = create(:user, admin: true)
-      expect(subject).to permit(admin, shopping_list)
+      it 'non-author admin users' do
+        # admin = create(:user, admin: true)
+        expect(subject).to permit(admin, shopping_list)
+      end
     end
   end
 
   permissions :edit? do
-    it 'denies access to visitors' do
-      no_user = nil
-      expect(subject).not_to permit(no_user, shopping_list)
+    describe 'denies access to...' do
+      it 'visitors' do
+        no_user = nil
+        expect(subject).not_to permit(no_user, shopping_list)
+      end
+
+      it 'non-author users' do
+        different_user = create(:user)
+        expect(subject).not_to permit(different_user, shopping_list)
+      end
     end
 
-    it 'denies access to non-author users' do
-      different_user = create(:user)
-      expect(subject).not_to permit(different_user, shopping_list)
-    end
+    describe 'permits access to...' do
+      it 'author users' do
+        expect(subject).to permit(author, shopping_list)
+      end
 
-    it 'permits access to author users' do
-      expect(subject).to permit(user, shopping_list)
-    end
-
-    it 'permits access to non-author admin users' do
-      admin = create(:user, admin: true)
-      expect(subject).to permit(admin, shopping_list)
+      it 'non-author admin users' do
+        # admin = create(:user, admin: true)
+        expect(subject).to permit(admin, shopping_list)
+      end
     end
   end
 
   permissions :update? do
-    it 'denies access to visitors' do
-      no_user = nil
-      expect(subject).not_to permit(no_user, shopping_list)
+    describe 'denies access to...' do
+      it 'visitors' do
+        no_user = nil
+        expect(subject).not_to permit(no_user, shopping_list)
+      end
+
+      it 'non-author users' do
+        different_user = create(:user)
+        expect(subject).not_to permit(different_user, shopping_list)
+      end
     end
 
-    it 'denies access to non-author users' do
-      different_user = create(:user)
-      expect(subject).not_to permit(different_user, shopping_list)
-    end
+    describe 'permits access to...' do
+      it 'author users' do
+        expect(subject).to permit(author, shopping_list)
+      end
 
-    it 'permits access to author users' do
-      expect(subject).to permit(user, shopping_list)
-    end
-
-    it 'permits access to non-author admin users' do
-      admin = create(:user, admin: true)
-      expect(subject).to permit(admin, shopping_list)
+      it 'non-author admin users' do
+        # admin = create(:user, admin: true)
+        expect(subject).to permit(admin, shopping_list)
+      end
     end
   end
 
   permissions :destroy? do
-    it 'denies access to visitors' do
-      no_user = nil
-      expect(subject).not_to permit(no_user, shopping_list)
+    describe 'it denies access to...' do
+      it 'visitors' do
+        no_user = nil
+        expect(subject).not_to permit(no_user, shopping_list)
+      end
+
+      it 'non-author users' do
+        different_user = create(:user)
+        expect(subject).not_to permit(different_user, shopping_list)
+      end
     end
 
-    it 'denies access to non-author users' do
-      different_user = create(:user)
-      expect(subject).not_to permit(different_user, shopping_list)
+    describe 'it permits access to...' do
+      it 'author users' do
+        expect(subject).to permit(author, shopping_list)
+      end
+
+      it 'non-author admin users' do
+        # admin = create(:user, admin: true)
+        expect(subject).to permit(admin, shopping_list)
+      end
     end
 
-    it 'permits access to author users' do
-      expect(subject).to permit(user, shopping_list)
-    end
+    describe 'default shopping list ("Grocery")' do
+      let(:default_shopping_list) { create(:shopping_list, user: author, main: true) }
 
-    it 'permits access to non-author admin users' do
-      admin = create(:user, admin: true)
-      expect(subject).to permit(admin, shopping_list)
+      it 'it denies authors' do
+        expect(subject).not_to permit(author, default_shopping_list)
+      end
+
+      it 'denies non-author admin' do
+        # admin = create(:user, admin: true)
+        expect(subject).not_to permit(admin, default_shopping_list)
+      end
+
+      it 'denies author admin' do
+        admin_author = create(:user, admin: true)
+        default_shopping_list = create(:shopping_list, user: admin_author, main: true)
+
+        expect(subject).not_to permit(admin_author, default_shopping_list)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problems Solved
* i mostly use the grocery list on this app
* i don't want to always make an extra click to get there with i sign in
* i moved some delete permission logic to the policy
* i added spec coverage for the new logic changes and also backfilled some spec coverage
* i made the grocery list items appear in alphabetical order by name under each aisle heading


## Considerations
The shopping_list show page requires a shopping list id, so now the shopping_list has a fallback of 
1 if it is in the params, return that list
2 if it is not in the params and the user has marked a "favorite list", return that list
3 if it is not in the params and the user has not chosen a "favorite list", return the default grocery list


## Things Learned
* the pundit gem does has view helpers

## Due Diligence Checks
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
