### PR TITLE
Add gem annotate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'net-pop', require: false
 gem 'net-imap', require: false
 
 group :development do
+  gem 'annotate'
   gem 'awesome_print'
   gem 'listen'
   # gem 'magic_frozen_string_literal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     awesome_print (1.9.2)
     axiom-types (0.1.1)
@@ -466,6 +469,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   awesome_print
   better_errors
   binding_of_caller

--- a/app/models/aisle.rb
+++ b/app/models/aisle.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: aisles
+#
+#  id           :bigint           not null, primary key
+#  name         :string
+#  order_number :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint
+#
+# Indexes
+#
+#  index_aisles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Aisle < ApplicationRecord
   extend Searchable
 

--- a/app/models/experimental_recipe.rb
+++ b/app/models/experimental_recipe.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: experimental_recipes
+#
+#  id         :bigint           not null, primary key
+#  source_url :string
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_experimental_recipes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class ExperimentalRecipe < ApplicationRecord
   extend Searchable
 

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: ingredients
+#
+#  id                :bigint           not null, primary key
+#  measurement_unit  :string           default(""), not null
+#  name              :string           default(""), not null
+#  preparation_style :string           default(""), not null
+#  quantity          :float            default(0.0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  recipe_id         :bigint
+#
+# Indexes
+#
+#  index_ingredients_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
+#
 class Ingredient < ApplicationRecord
   belongs_to :recipe, inverse_of: :ingredients
   before_save :format_name

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: inventories
+#
+#  id         :bigint           not null, primary key
+#  items      :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_inventories_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Inventory < ApplicationRecord
   belongs_to :user
 end

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: meal_plans
+#
+#  id            :bigint           not null, primary key
+#  notes         :text
+#  people_served :integer          default(0), not null
+#  prepared_on   :date             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :bigint
+#
+# Indexes
+#
+#  index_meal_plans_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class MealPlan < ApplicationRecord
   belongs_to :user
   has_many :meal_plan_recipes, dependent: :destroy

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: meal_plan_recipes
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  meal_plan_id :bigint
+#  recipe_id    :bigint
+#
+# Indexes
+#
+#  index_meal_plan_recipes_on_meal_plan_id  (meal_plan_id)
+#  index_meal_plan_recipes_on_recipe_id     (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (meal_plan_id => meal_plans.id)
+#  fk_rails_...  (recipe_id => recipes.id)
+#
 class MealPlanRecipe < ApplicationRecord
   belongs_to :meal_plan
   belongs_to :recipe

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,5 +1,39 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id                    :bigint           not null, primary key
+#  archived              :boolean          default(FALSE)
+#  cook_time             :integer          default(0), not null
+#  extra_work_note       :string
+#  image_url             :string           default(""), not null
+#  instructions          :text             default(""), not null
+#  last_prepared_on      :date
+#  notes                 :text
+#  nutrition_data_iframe :text
+#  pepperplate_url       :string
+#  prep_day_instructions :text             default("")
+#  prep_time             :integer          default(0), not null
+#  reheat_instructions   :text             default("")
+#  reheat_time           :integer          default(0)
+#  servings              :integer          default(0), not null
+#  source_name           :string           default(""), not null
+#  source_url            :string           default(""), not null
+#  title                 :string           default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_recipes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Recipe < ApplicationRecord
   extend Searchable
 

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: scheduled_deliveries
+#
+#  id               :bigint           not null, primary key
+#  scheduled_for    :datetime
+#  service_provider :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  shopping_list_id :bigint           not null
+#
+# Indexes
+#
+#  index_scheduled_deliveries_on_shopping_list_id  (shopping_list_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (shopping_list_id => shopping_lists.id)
+#
 class ScheduledDelivery < ApplicationRecord
   belongs_to :shopping_list
 

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: shopping_lists
+#
+#  id         :bigint           not null, primary key
+#  favorite   :boolean          default(FALSE)
+#  main       :boolean          default(FALSE)
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_shopping_lists_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class ShoppingList < ApplicationRecord
   extend Searchable
   DEFAULT_NAME = 'grocery'

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: shopping_list_items
+#
+#  id                   :bigint           not null, primary key
+#  heb_upc              :string
+#  name                 :string
+#  quantity             :float
+#  recurrence_frequency :string
+#  recurrence_quantity  :float            default(0.0)
+#  status               :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  aisle_id             :bigint
+#  shopping_list_id     :bigint
+#
+# Indexes
+#
+#  index_shopping_list_items_on_aisle_id          (aisle_id)
+#  index_shopping_list_items_on_shopping_list_id  (shopping_list_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (aisle_id => aisles.id)
+#  fk_rails_...  (shopping_list_id => shopping_lists.id)
+#
 class ShoppingListItem < ApplicationRecord
   extend Searchable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE)
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'true',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/aisles.rb
+++ b/spec/factories/aisles.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: aisles
+#
+#  id           :bigint           not null, primary key
+#  name         :string
+#  order_number :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint
+#
+# Indexes
+#
+#  index_aisles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :aisle do
     user_id { create(:user).id }

--- a/spec/factories/experimental_recipes.rb
+++ b/spec/factories/experimental_recipes.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: experimental_recipes
+#
+#  id         :bigint           not null, primary key
+#  source_url :string
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_experimental_recipes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :experimental_recipe do
     user

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: ingredients
+#
+#  id                :bigint           not null, primary key
+#  measurement_unit  :string           default(""), not null
+#  name              :string           default(""), not null
+#  preparation_style :string           default(""), not null
+#  quantity          :float            default(0.0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  recipe_id         :bigint
+#
+# Indexes
+#
+#  index_ingredients_on_recipe_id  (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipe_id => recipes.id)
+#
 FactoryBot.define do
   factory :ingredient do
     recipe { association(:recipe) }

--- a/spec/factories/inventories.rb
+++ b/spec/factories/inventories.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: inventories
+#
+#  id         :bigint           not null, primary key
+#  items      :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_inventories_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :inventory do
     user { nil }

--- a/spec/factories/meal_plan_recipes.rb
+++ b/spec/factories/meal_plan_recipes.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: meal_plan_recipes
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  meal_plan_id :bigint
+#  recipe_id    :bigint
+#
+# Indexes
+#
+#  index_meal_plan_recipes_on_meal_plan_id  (meal_plan_id)
+#  index_meal_plan_recipes_on_recipe_id     (recipe_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (meal_plan_id => meal_plans.id)
+#  fk_rails_...  (recipe_id => recipes.id)
+#
 FactoryBot.define do
   factory :meal_plan_recipe do
     meal_plan

--- a/spec/factories/meal_plans.rb
+++ b/spec/factories/meal_plans.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: meal_plans
+#
+#  id            :bigint           not null, primary key
+#  notes         :text
+#  people_served :integer          default(0), not null
+#  prepared_on   :date             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :bigint
+#
+# Indexes
+#
+#  index_meal_plans_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :meal_plan do
     user

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -1,5 +1,39 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: recipes
+#
+#  id                    :bigint           not null, primary key
+#  archived              :boolean          default(FALSE)
+#  cook_time             :integer          default(0), not null
+#  extra_work_note       :string
+#  image_url             :string           default(""), not null
+#  instructions          :text             default(""), not null
+#  last_prepared_on      :date
+#  notes                 :text
+#  nutrition_data_iframe :text
+#  pepperplate_url       :string
+#  prep_day_instructions :text             default("")
+#  prep_time             :integer          default(0), not null
+#  reheat_instructions   :text             default("")
+#  reheat_time           :integer          default(0)
+#  servings              :integer          default(0), not null
+#  source_name           :string           default(""), not null
+#  source_url            :string           default(""), not null
+#  title                 :string           default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_recipes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :recipe do
     user

--- a/spec/factories/scheduled_deliveries.rb
+++ b/spec/factories/scheduled_deliveries.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: scheduled_deliveries
+#
+#  id               :bigint           not null, primary key
+#  scheduled_for    :datetime
+#  service_provider :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  shopping_list_id :bigint           not null
+#
+# Indexes
+#
+#  index_scheduled_deliveries_on_shopping_list_id  (shopping_list_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (shopping_list_id => shopping_lists.id)
+#
 FactoryBot.define do
   factory :scheduled_delivery do
     shopping_list

--- a/spec/factories/shopping_list_items.rb
+++ b/spec/factories/shopping_list_items.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: shopping_list_items
+#
+#  id                   :bigint           not null, primary key
+#  heb_upc              :string
+#  name                 :string
+#  quantity             :float
+#  recurrence_frequency :string
+#  recurrence_quantity  :float            default(0.0)
+#  status               :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  aisle_id             :bigint
+#  shopping_list_id     :bigint
+#
+# Indexes
+#
+#  index_shopping_list_items_on_aisle_id          (aisle_id)
+#  index_shopping_list_items_on_shopping_list_id  (shopping_list_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (aisle_id => aisles.id)
+#  fk_rails_...  (shopping_list_id => shopping_lists.id)
+#
 FactoryBot.define do
   factory :shopping_list_item do
     shopping_list_id { create(:shopping_list).id }

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: shopping_lists
+#
+#  id         :bigint           not null, primary key
+#  favorite   :boolean          default(FALSE)
+#  main       :boolean          default(FALSE)
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_shopping_lists_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :shopping_list do
     user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE)
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@email.com" }


### PR DESCRIPTION
## Problems Solved
* the [`annotate` gem](https://github.com/ctran/annotate_models#configuration-in-rails) annotates chosen files (i chose models and factories) with the schema information for the associated table
* this makes it easier to know what fields you have available to you while working in models and specs
* it also lets you know what db defaults you have in place
* i like this
* this PR is a no-op. it only changes a `development` group gem and only adds comments to any app code files.

## Due Diligence Checks
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
