### PR TITLE
Fix cross-list bug and in_cart display

### DIFF
--- a/app/helpers/shopping_lists_helper.rb
+++ b/app/helpers/shopping_lists_helper.rb
@@ -22,19 +22,17 @@ module ShoppingListsHelper
   end
 
   def scheduled_delivery_status(item)
-    return nil unless item.list.scheduled_deliveries.future.any?
-
-    return button_to MaterialIcon.new(icon: :add_shopping_cart, size: :large, classes: 'js-add-to-cart', title: 'Click to mark item as scheduled for home delivery.').render,
+    return button_to(MaterialIcon.new(icon: :add_shopping_cart, size: :large, classes: 'js-add-to-cart', title: 'Click to mark item as scheduled for home delivery.').render,
                     add_to_cart_path(id: item.id),
                     method: :post,
                     class: 'icon-button',
-                    remote: true if item.active?
+                    remote: true) if item.active? && item.list.scheduled_deliveries.future.any?
 
-    return button_to MaterialIcon.new(icon: :shopping_bag, size: :large, classes: 'text-warning js-remove-from-cart', title: 'Item is scheduled for home delivery. Click to remove.').render,
+    return button_to(MaterialIcon.new(icon: :shopping_bag, size: :large, classes: 'text-warning js-remove-from-cart', title: 'Item is scheduled for home delivery. Click to remove.').render,
               remove_from_cart_path(id: item.id),
               method: :post,
               class: 'icon-button',
-              remote: true if item.in_cart?
+              remote: true) if item.in_cart?
   end
 
   private

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -49,11 +49,7 @@ class ShoppingListItem < ApplicationRecord
 
   scope :active, -> { where(status: 'active') }
   scope :inactive, -> { where(status: 'inactive') }
-  # DEPRECATION WARNING: Class level methods will no longer inherit scoping from `not_purchased`
-  # in Rails 6.1. To continue using the scoped relation, pass it into the blockdirectly. To instead
-  # access the full set of models, as Rails 6.1 will, use `ShoppingListItem.default_scoped`. (called
-  # from block in <class:ShoppingListItem> at app/models/shopping_list_item.rb:25)
-  scope :not_purchased, -> { where(status: 'active').or(ShoppingListItem.where(status: 'in_cart')) }
+  scope :not_purchased, -> { where(status: 'active').or(self.where(status: 'in_cart')) }
 
   def self.by_recently_edited
     order(updated_at: 'DESC')


### PR DESCRIPTION
## Related Issues & PRs
Closes #551

## Problems Solved
| Problem | Solution |
|---|---|
| "in cart" items showing up on more than one shopping list |"in cart" items now only show up on their parent shopping list. |
| "in cart" icon does not display if there is no associated upcoming delivery | if an item is marked as "in cart" even if there is no upcoming associated delivery, it now displays|


## Things Learned
* Starting in Rails 6.1, scope syntax for `or` clauses no longer supported calling directly on the class. It has to be called on `self`. 
* https://stackoverflow.com/a/58650984