### PR TITLE
789: Style ingredients portion of recipe form. Use number input for qty

### DIFF
--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -30,25 +30,26 @@
   }
 
   input#recipe_archived {
-    width: 30px;
     margin-left: 20px;
+    width: 30px;
   }
 
 }
 
 // Ingredients form styling
-#ingredients-container {
+.ingredients-container {
   margin-top: 1rem;
   overflow-x: scroll;
 
-  #ingredients-header {
+  .ingredients-header {
+    border-radius: .25rem;
     display: flex;
-    border-radius: 0.25rem;
     font-weight: bold;
+
     .ingredients-col {
-      padding: 0 5px;
       background: $brand-light-blue;
       border: 1px solid $light-gray;
+      padding: 0 5px;
     }
   }
 
@@ -59,27 +60,29 @@
   .ingredients-col {
     flex: 1 1 20%;
     min-width: 180px;
+
     .form-control {
-      padding: 5px 3px;
       min-width: 100px;
+      padding: 5px 3px;
     }
   }
 
   .flex-sm {
-    min-width: 50px;
     flex: 1 1 10%;
+    min-width: 50px;
   }
 
   .flex-xs {
+    border: 1px solid $bootstrap-grey;
+    flex: 0 1 10px;
     min-width: 1.25rem;
     padding: 3px;
     text-align: center;
-    flex: 0 1 10px;
-    border: 1px solid #ced4da;
+
     .material-symbols-outlined {
+      left: -3px;
       position: relative;
       top: 0;
-      left: -3px;
     }
   }
 }

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -34,52 +34,52 @@
     margin-left: 20px;
   }
 
-  // Ingredients form styling
+}
 
-  #ingredients-container {
-    margin-top: 1rem;
-    overflow-x: scroll;
+// Ingredients form styling
+#ingredients-container {
+  margin-top: 1rem;
+  overflow-x: scroll;
 
-    #ingredients-header {
-      display: flex;
-      border-radius: 0.25rem;
-      font-weight: bold;
-      .ingredients-col {
-        padding: 0 5px;
-        background: $brand-light-blue;
-        border: 1px solid $light-gray;
-      }
-    }
-
-    .ingredients-row {
-      display: flex;
-    }
-
+  #ingredients-header {
+    display: flex;
+    border-radius: 0.25rem;
+    font-weight: bold;
     .ingredients-col {
-      flex: 1 1 20%;
-      min-width: 180px;
-      .form-control {
-        padding: 5px 3px;
-        min-width: 100px;
-      }
+      padding: 0 5px;
+      background: $brand-light-blue;
+      border: 1px solid $light-gray;
     }
+  }
 
-    .flex-sm {
-      min-width: 50px;
-      flex: 1 1 10%;
+  .ingredients-row {
+    display: flex;
+  }
+
+  .ingredients-col {
+    flex: 1 1 20%;
+    min-width: 180px;
+    .form-control {
+      padding: 5px 3px;
+      min-width: 100px;
     }
+  }
 
-    .flex-xs {
-      min-width: 1.25rem;
-      padding: 3px;
-      text-align: center;
-      flex: 0 1 10px;
-      border: 1px solid #ced4da;
-      .material-symbols-outlined {
-        position: relative;
-        top: 0;
-        left: -3px;
-      }
+  .flex-sm {
+    min-width: 50px;
+    flex: 1 1 10%;
+  }
+
+  .flex-xs {
+    min-width: 1.25rem;
+    padding: 3px;
+    text-align: center;
+    flex: 0 1 10px;
+    border: 1px solid #ced4da;
+    .material-symbols-outlined {
+      position: relative;
+      top: 0;
+      left: -3px;
     }
   }
 }

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -28,6 +28,60 @@
     border: 0;
     margin-top: 1rem;
   }
+
+  input#recipe_archived {
+    width: 30px;
+    margin-left: 20px;
+  }
+
+  // Ingredients form styling
+
+  #ingredients-container {
+    margin-top: 1rem;
+    overflow-x: scroll;
+
+    #ingredients-header {
+      display: flex;
+      border-radius: 0.25rem;
+      font-weight: bold;
+      .ingredients-col {
+        padding: 0 5px;
+        background: $brand-light-blue;
+        border: 1px solid $light-gray;
+      }
+    }
+
+    .ingredients-row {
+      display: flex;
+    }
+
+    .ingredients-col {
+      flex: 1 1 20%;
+      min-width: 180px;
+      .form-control {
+        padding: 5px 3px;
+        min-width: 100px;
+      }
+    }
+
+    .flex-sm {
+      min-width: 50px;
+      flex: 1 1 10%;
+    }
+
+    .flex-xs {
+      min-width: 1.25rem;
+      padding: 3px;
+      text-align: center;
+      flex: 0 1 10px;
+      border: 1px solid #ced4da;
+      .material-symbols-outlined {
+        position: relative;
+        top: 0;
+        left: -3px;
+      }
+    }
+  }
 }
 
 .image-container {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -19,4 +19,5 @@ $light-gray: #f1f1f1;
 $gray: #808080;
 $medium-gray: #ccc;
 $link-color: $brand-light-blue;
+$bootstrap-grey: #ced4da;
 // $error: ff0000;

--- a/app/views/ingredients/_form_fields.html.erb
+++ b/app/views/ingredients/_form_fields.html.erb
@@ -1,14 +1,14 @@
-<td><%= f_ingredient.text_field :quantity, class: 'form-control input--small' %></td>
-<td>
-  <%= f_ingredient.select :measurement_unit,
+<div class='ingredients-col flex-sm'><%= f_ingredient.number_field :quantity, class: 'form-control', step: 'any' %></div>
+
+  <div class='ingredients-col'><%= f_ingredient.select :measurement_unit,
                           options_for_select(Ingredient::UNITS, selected: f_ingredient.object.measurement_unit),
                           {include_blank: true},
-                          class: 'form-control' %>
-</td>
-<td><%= f_ingredient.text_field :name, class: 'form-control' %></td>
-<td>
-  <%= f_ingredient.text_field :preparation_style,
+                          class: 'form-control' %></div>
+
+<div class='ingredients-col'><%= f_ingredient.text_field :name, class: 'form-control' %></div>
+
+<div class='ingredients-col'><%= f_ingredient.text_field :preparation_style,
                               placeholder: 'Ex: rinsed and drained',
-                              class: 'form-control' %>
-</td>
-<td><%= f_ingredient.check_box :_destroy if f_ingredient.object.persisted? %></td>
+                              class: 'form-control' %></div>
+
+<div class='ingredients-col flex-xs'><%= f_ingredient.check_box :_destroy if f_ingredient.object.persisted? %></div>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -85,22 +85,18 @@
       </div>
     </div> <!-- row -->
 
-    <table class="table table-ingredients">
-      <thead>
-        <tr>
-          <th>Qty</th>
-          <th>Measurement</th>
-          <th>Name</th>
-          <th>Preparation Style</th>
-          <th>Delete?</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= form.fields_for :ingredients do |f_ingredient| %>
-          <tr><%= render 'ingredients/form_fields', f_ingredient: f_ingredient %></tr>
-        <% end %>
-      </tbody>
-    </table>
+    <section id='ingredients-container'>
+      <header id='ingredients-header'>
+        <div class="ingredients-col flex-sm">Qty</div>
+        <div class="ingredients-col">Measurement</div>
+        <div class="ingredients-col">Name</div>
+        <div class="ingredients-col">Prep Style</div>
+        <div class="ingredients-col flex-xs"><%= MaterialIcon.new(icon: :trash, size: :medium).render %></div>
+      </header>
+      <%= form.fields_for :ingredients do |f_ingredient| %>
+        <div class='ingredients-row'><%= render 'ingredients/form_fields', f_ingredient: f_ingredient %></div>
+      <% end %>
+    </section>
 
     <div class="field">
       <%= form.label 'Instructions' %>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -85,8 +85,8 @@
       </div>
     </div> <!-- row -->
 
-    <section id='ingredients-container'>
-      <header id='ingredients-header'>
+    <section class='ingredients-container'>
+      <header class='ingredients-header'>
         <div class="ingredients-col flex-sm">Qty</div>
         <div class="ingredients-col">Measurement</div>
         <div class="ingredients-col">Name</div>

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe Ingredient, type: :model do
       it { should validate_inclusion_of(:measurement_unit).in_array(Ingredient::UNITS) }
     end
 
+    context 'quantity' do
+      it 'is valid with a float' do
+        ingredient.quantity = '0.0222'
+        expect(ingredient.valid?).to be true
+      end
+
+      it 'is valid with an integer' do
+        ingredient.quantity = '2'
+        expect(ingredient.valid?).to be true
+      end
+
+      it 'is valid with a space' do
+        ingredient.quantity = '    0.2222   '
+        expect(ingredient.valid?).to be true
+      end
+
+      it 'is invalid with a non-number' do
+        ingredient.quantity = 'tacos'
+        expect(ingredient.valid?).to be false
+      end
+    end
+
     context 'a valid preparation_style' do
       let(:invalid_style) { 'invalid style' }
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #789

## INFO
I'm not sure how you want this to look or behave, so please feel free to take this and do what you want with it. No need to ask me if I'm okay with it: you can feel free to discard or edit as you'd like. I was mainly just trying to practice CSS.

## Problems Solved
* Regarding the numericality validation, I was unable to reproduce that. To help prevent errors and/or debug when it _does_ happen, I changed the input type to number, and added some tests in the model to make it easier to tweak them if the probelm arises.
* I changed html in the ingredients section from a table to a divs with flex. 

## Screenshots
| Before | After |
|----------|----------|
|<img width="1136" alt="ingredients-desktop-before" src="https://github.com/lortza/food_planner/assets/7945260/59f824b5-7e85-43d4-b2c6-3c4fde142862"> | <img width="1198" alt="ingredients-desktop-after" src="https://github.com/lortza/food_planner/assets/7945260/27be9e45-61c6-466f-91a1-31897069159d"> |
| <img width="355" alt="ingredients-moblile-before" src="https://github.com/lortza/food_planner/assets/7945260/2752bbb8-3afc-475a-bc47-eca8e897e332"> | <img width="378" alt="ingredients-mobile-after" src="https://github.com/lortza/food_planner/assets/7945260/3b977a7c-897a-4d41-8e03-2caabbd85693">|

screencast of mobile after:

https://github.com/lortza/food_planner/assets/7945260/5102232b-ccb0-4040-878c-767b844f7e52

## Things Learned
* CSS is hard 😅

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work (well, backend)
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
