### PR TITLE
Bug fix: shopping list aisle being removed when items "in_cart"

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,7 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
-//= require action_cable
+//= require actioncable
 //= require_self
 //= require_tree ./channels
 

--- a/app/controllers/shopping_list_item_statuses_controller.rb
+++ b/app/controllers/shopping_list_item_statuses_controller.rb
@@ -21,7 +21,7 @@ class ShoppingListItemStatusesController < ApplicationController
   def deactivate
     # crosses an item off of the list
     @shopping_list_item.deactivate!
-    @remove_aisle = @shopping_list_item.list.items.active.where(aisle: @shopping_list_item.aisle).blank?
+    @remove_aisle = @shopping_list_item.list.items.not_purchased.where(aisle: @shopping_list_item.aisle).blank?
     respond_to :js
   end
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #793

## Problems Solved
* The `deactivate` controller action was not taking into account shopping list items that were `in_cart`. Since all items were `in_cart` an no items were `active`, the controller thought the aisle was empty.
* Scoping against `not_purcahsed` instead of `active` fixed the glitch

## Due Diligence Checks
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
