### PR TITLE
Add image to experimental recipes

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -51,9 +51,9 @@ jobs:
         uses: ruby/setup-ruby@8f312efe1262fb463d906e9bf040319394c18d3e # v1.92
         with:
           bundler-cache: true
-      - name: Lint CSS
-        run: bundle exec scss-lint app/assets/stylesheets/**.scss
       # Add or replace any other lints here
+      # - name: Lint CSS
+      #   run: bundle exec scss-lint app/assets/stylesheets/**.scss
       # - name: Rubocop
       #   run: bundle exec rubocop --parallel
       # - name: Reek

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -10,3 +10,16 @@
   margin: 0;
   padding: 0;
 }
+
+// MATERIAL ICONS
+// https://fonts.google.com/icons
+
+// Options:
+// font-variation-settings:
+// 'FILL' 0,
+// 'wght' 400,
+// 'GRAD' 0,
+// 'opsz' 24
+
+.icon-outlined { font-variation-settings: 'FILL' 0 }
+.icon-filled { font-variation-settings: 'FILL' 1 }

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -21,5 +21,5 @@
 // 'GRAD' 0,
 // 'opsz' 24
 
-.icon-outlined { font-variation-settings: 'FILL' 0 }
-.icon-filled { font-variation-settings: 'FILL' 1 }
+.icon-outlined { font-variation-settings: 'FILL' 0; }
+.icon-filled { font-variation-settings: 'FILL' 1; }

--- a/app/components/material_icon.rb
+++ b/app/components/material_icon.rb
@@ -4,11 +4,12 @@ class MaterialIcon
   # https://fonts.google.com/icons
   include ActionView::Helpers::TagHelper
 
-  def initialize(icon:, title: nil, size: :inherit, classes: nil)
+  def initialize(icon:, title: nil, size: :inherit, filled: false, classes: nil)
     @icon = icon
     @title = title
     @size = size
-    @classes = classes
+    @filled = filled ? 'icon-filled' : 'icon-outlined'
+    @provided_classes = classes
   end
 
   def render
@@ -30,8 +31,7 @@ class MaterialIcon
     when :settings then settings;
     when :shopping_bag then shopping_bag;
     when :shopping_cart then shopping_cart;
-    when :star_filled then star_filled;
-    when :star_outline then star_outline;
+    when :star then star;
     when :sync then sync;
     when :trash then trash;
     when :truck then truck;
@@ -44,134 +44,128 @@ class MaterialIcon
 
   def add_shopping_cart
     content_tag(:span, 'add_shopping_cart',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Add to cart')
   end
 
   def arrow_left
     content_tag(:span, 'arrow_back',
-      class: "#{symbol_base_classes} #{@classes} nav-link-icon left",
+      class: "#{symbol_classes} nav-link-icon left",
       title: @title.presence || 'Back')
   end
 
   def archived
     content_tag(:span, 'inventory_2',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Archived')
   end
 
   def calendar_clock
     content_tag(:span, 'calendar_clock',
-      class: "#{symbol_base_classes} #{@classes} text-warning",
+      class: "#{symbol_classes} text-warning",
       title: @title.presence || "It's been a while")
   end
 
   def clock
     content_tag(:span, 'update',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Duration warning')
   end
 
   def checkmark
     content_tag(:span, 'done',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Done')
   end
 
   def copy
     content_tag(:span, 'file_copy',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Copy')
   end
 
   def edit_note
     content_tag(:span, 'edit_note',
-      class: "#{symbol_base_classes} #{@classes} float-right",
+      class: "#{symbol_classes} float-right",
       title: @title.presence || 'Edit')
   end
 
   def event_repeat
     content_tag(:span, 'event_repeat',
-      class: "#{symbol_base_classes} #{@classes}",
-      title: @title.presence || 'Sync')
+      class: symbol_classes,
+      title: @title.presence || 'Repeated')
   end
 
   def info
     content_tag(:span, 'info',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Info')
   end
 
   def new_release
     content_tag(:span, 'new_releases',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'New')
   end
 
   def plus_circle
     content_tag(:span, 'add_circle',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Add')
   end
 
   def plus_square
     content_tag(:span, 'add_box',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Add to list')
   end
 
   def shopping_bag
     content_tag(:span, 'shopping_bag',
-      class: "#{icon_base_classes} #{@classes}",
+      class: icon_classes,
       title: @title.presence || 'In shopping bag')
   end
 
   def shopping_cart
     content_tag(:span, 'shopping_cart',
-      class: "#{icon_base_classes} #{@classes}",
+      class: icon_classes,
       title: @title.presence || 'Cart')
   end
 
-  def star_filled
+  def star
     content_tag(:span, 'star',
-      class: "#{icon_base_classes} #{@classes}",
-      title: @title.presence || 'Starred')
-  end
-
-  def star_outline
-    content_tag(:span, 'star',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Star')
   end
 
   def settings
     content_tag(:span, 'settings',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Settings')
   end
 
   def search
     content_tag(:span, 'search',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Search',
       aria: {hidden: true})
   end
 
   def sync
     content_tag(:span, 'sync',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Sync')
   end
 
   def trash
     content_tag(:span, 'delete',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Delete')
   end
 
   def truck
     content_tag(:span, 'local_shipping',
-      class: "#{symbol_base_classes} #{@classes}",
+      class: symbol_classes,
       title: @title.presence || 'Delivery')
   end
 
@@ -189,15 +183,20 @@ class MaterialIcon
     end
   end
 
-  def symbol_base_classes
-    "material-symbols-outlined #{base_classes}"
+  def symbol_classes
+    "material-symbols-outlined #{computed_classes}"
   end
 
-  def icon_base_classes
-    "material-icons-outlined #{base_classes}"
+  def icon_classes
+    # icon classes do not support "filled"
+    "material-icons-outlined #{computed_classes}"
+  end
+
+  def computed_classes
+    "#{base_classes} #{size_class} #{@filled} #{@provided_classes}"
   end
 
   def base_classes
-    "#{size_class} align-middle"
+    "align-middle"
   end
 end

--- a/app/controllers/experimental_recipes_controller.rb
+++ b/app/controllers/experimental_recipes_controller.rb
@@ -51,6 +51,6 @@ class ExperimentalRecipesController < ApplicationController
   end
 
   def experimental_recipe_params
-    params.require(:experimental_recipe).permit(:title, :source_url, :user_id)
+    params.require(:experimental_recipe).permit(:title, :source_url, :image_url, :user_id)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -69,6 +69,7 @@ class RecipesController < ApplicationController
       title: experimental_recipe.title,
       source_name: URI.parse(experimental_recipe.source_url).host.gsub('www.', ''),
       source_url: experimental_recipe.source_url,
+      image_url: experimental_recipe.image_url,
       experimental_recipe_id: experimental_recipe.id,
       instructions: Scraper.new(experimental_recipe.source_url).site_data
     )

--- a/app/helpers/shopping_lists_helper.rb
+++ b/app/helpers/shopping_lists_helper.rb
@@ -4,11 +4,11 @@ module ShoppingListsHelper
   def toggle_favorite(list)
     if list.favorite
       # Show the filled star and link to "unfavorite" it
-      link_to MaterialIcon.new(icon: :star_filled, classes: 'text-warning').render,
+      link_to MaterialIcon.new(icon: :star, filled: true, title: 'Click to unfavorite', classes: 'text-warning').render,
         shopping_list_favorite_path(list), method: :delete
     else
       # Show the outlined star and link to "favorite" it
-      link_to MaterialIcon.new(icon: :star_outline).render,
+      link_to MaterialIcon.new(icon: :star, filled: false, title: 'Click to favorite').render,
         shopping_list_favorites_path(id: list.id), method: :post
     end
   end

--- a/app/models/experimental_recipe.rb
+++ b/app/models/experimental_recipe.rb
@@ -5,6 +5,7 @@
 # Table name: experimental_recipes
 #
 #  id         :bigint           not null, primary key
+#  image_url  :string
 #  source_url :string
 #  title      :string
 #  created_at :datetime         not null

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -24,11 +24,14 @@ class Scraper
     # @client.initialize_http_header({'User-Agent' => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36" })
     # response = @client.request_get(@endpoint)
     # JSON.parse(response)
-    html = URI.open(@endpoint)
-    doc = Nokogiri::HTML(html)
-    items = doc.css("li").filter_map { |li| li.text.squish unless li.text.blank? }
-    items.join("\n")
-
+    begin
+      html = URI.open(@endpoint)
+      doc = Nokogiri::HTML(html)
+      items = doc.css("li").filter_map { |li| li.text.squish unless li.text.blank? }
+      items.join("\n")
+    rescue
+      "could not scrape"
+    end
     # lis = doc.css('li')
     # ingredient_heading = doc.at('h2:contains("Ingredients")') || doc.at('h3:contains("Ingredients")') || doc.at('h4:contains("Ingredients")')
     # instructions_heading = doc.at('h2:contains("Instructions")') || doc.at('h3:contains("Instructions")') || doc.at('h4:contains("Instructions")')

--- a/app/views/experimental_recipes/_form.html.erb
+++ b/app/views/experimental_recipes/_form.html.erb
@@ -12,6 +12,11 @@
     <%= form.text_field :source_url, class: 'form-control' %>
   </div>
 
+  <div class="field">
+    <%= form.label :image_url %>
+    <%= form.text_field :image_url, class: 'form-control' %>
+  </div>
+
   <div class="actions">
     <%= form.submit class: button_classes('success mt-2') %>
   </div>

--- a/app/views/experimental_recipes/index.html.erb
+++ b/app/views/experimental_recipes/index.html.erb
@@ -5,19 +5,27 @@
 <h1>Recipes to Try</h1>
 <p>Save interesting recipes that we'd like to try here. Once we make a recipe, if we like it, we will add it in to our regular recipes collection.</p>
 
-<table class="table">
+<table class="table table-sm table--recipes-index">
   <thead>
     <tr>
-      <th>Recipe</th>
+      <th colspan='2'>Recipe</th>
       <th colspan='3'>Manage</th>
     </tr>
   </thead>
   <tbody>
     <% @experimental_recipes.each do |recipe| %>
       <tr>
+        <td>
+          <div class="img--container">
+            <%= link_to (image_tag guaranteed_image(recipe), alt: recipe.title), recipe, 'aria-label': 'Go to recipe' %>
+          </div>
+        </td>
         <td><%= link_to recipe.title, recipe.source_url, target: '_blank' %></td>
-        <td><%= link_to 'edit', edit_experimental_recipe_path(recipe) %></td>
-        <td><%= link_to 'delete', recipe, method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' } %></td>
+        <td><%= link_to MaterialIcon.new(icon: :settings, size: :xlarge, title: 'Edit recipe').render, edit_experimental_recipe_path(recipe), 'aria-label': 'Edit recipe' %></td>
+        <td>
+          <%= link_to MaterialIcon.new(icon: :trash, size: :xlarge, title: 'Delete recipe').render,
+                recipe, method: :delete, 'aria-label': 'Delete recipe', data: { confirm: 'Are you sure? This action cannot be undone.' } %>
+        </td>
         <td><%= link_to 'convert to recipe', convert_from_experimental_path(experimental_recipe_id: recipe.id), method: :post %></td>
       </tr>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
   <head>
     <title><%= raw page_title %></title>
     <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">

--- a/app/views/shared/navbar/_main.html.erb
+++ b/app/views/shared/navbar/_main.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-sm navbar-light bg-light mb-3">
-  <%= image_tag('icon.png', class: 'brand-icon') %><%= link_to 'FoodPlanner', root_url, class: 'navbar-brand' %>
+  <%= image_tag('icon.png', class: 'brand-icon', alt: 'site logo') %><%= link_to 'FoodPlanner', root_url, class: 'navbar-brand' %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/db/migrate/20231123123608_add_image_url_to_experimental_recipes.rb
+++ b/db/migrate/20231123123608_add_image_url_to_experimental_recipes.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToExperimentalRecipes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :experimental_recipes, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_07_144321) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_23_123608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_07_144321) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image_url"
     t.index ["user_id"], name: "index_experimental_recipes_on_user_id"
   end
 

--- a/spec/factories/experimental_recipes.rb
+++ b/spec/factories/experimental_recipes.rb
@@ -5,6 +5,7 @@
 # Table name: experimental_recipes
 #
 #  id         :bigint           not null, primary key
+#  image_url  :string
 #  source_url :string
 #  title      :string
 #  created_at :datetime         not null


### PR DESCRIPTION
## Problems Solved
* adds an image to the experimental recipes page
* converts word links to icon links on the experimental recipes page
* adds accessibility improvements to application layout
* adds "filled" support to icon component
* replaces existing "star" icon with new filled-support version
* allows scraper to recover from when a recipe page blocks the copy attempt

## Screenshots
<img width="1403" alt="Screen Shot 2023-11-23 at 10 50 48 AM" src="https://github.com/lortza/food_planner/assets/8680712/6949d306-41bc-4e27-804b-ae2dd8d1179b">


## Things Learned
* google material "icons" do not support filled/outlined modifications but their "symbols" do
* i was going to add automatic `aria-label`s to the icon class, but that label should go on the link, not the icon.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
