### PR TITLE
Change simplecov github integration to joshmfrankel

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -39,11 +39,14 @@ jobs:
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec
-      - name: SimpleCov Report
-        uses: aki77/simplecov-report-action@v1
+      - uses: joshmfrankel/simplecov-check-action@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failedThreshold: 0
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: SimpleCov Report
+      #   uses: aki77/simplecov-report-action@v1
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     failedThreshold: 0
       - name: Check Seeds
         run: bundle exec rake db:seed
 

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: joshmfrankel/simplecov-check-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          minimum_suite_coverage: 0
+          coverage_path: 'coverage/.last_run.json'
       # - name: SimpleCov Report
       #   uses: aki77/simplecov-report-action@v1
       #   with:

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :test do
   gem 'launchy' # open browser with save_and_open_page
   gem 'rails-controller-testing' # allows for controller testing
   gem 'shoulda-matchers' # library for easier testing syntax
-  gem 'simplecov' # using to display rspec coverage in PR comment
+  gem 'simplecov', require: false # using to display rspec coverage in PR comment
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
## Related Issues & PRs
I was getting errors on PRs for the https://github.com/marketplace/actions/simplecov-report integration.

This PR switches to a different integration: https://github.com/marketplace/actions/simplecov-action (settings https://github.com/joshmfrankel/simplecov-check-action/blob/main/action.yml)
