### PR TITLE
Restyle recipe show

### DIFF
--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -38,3 +38,20 @@
   width: 100%;
   .image { width: 100%; }
 }
+
+.recipe-show-stats {
+  display: flex;
+  border-top: 1px solid gray;
+  padding-top: .25rem;
+  font-family: Function,'Trebuchet MS',Arial,sans-serif;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+  justify-content: flex-start;
+}
+
+.recipe-show-stats > * {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+}

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -9,25 +9,30 @@
       <%= @recipe.title %>
       <sup><%= extra_work_flag(@recipe) if current_user.present? %> <%= status_flag(@recipe) %></sup>
     </h1>
-    <p>
-      Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank' %>
-    </p>
+    <div class='recipe-show-stats text-small'>
+      <div>Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank' %></div>
+      <div>Servings: <%= @recipe.servings %></div>
+      <div>Prep Time: <%= display_time(@recipe.prep_time) %></div>
+      <div>Cook Time: <%= display_time(@recipe.cook_time) %></div>
+      <div>Total Time: <%= display_time(@recipe.total_time) %></div>
+      <div>Reheat Time: <%= display_time(@recipe.reheat_time) %></div>
+      <div>Prepared: <%= pluralize(@recipe.frequency, 'time') %></div>
+    </div>
   </div>
 </div><!-- row -->
 
 <div class='row'>
+  <!-- Left side content -->
   <div class='col-md-8 col-sm-12'>
     <div class='row'>
       <div class='col-md-6 col-sm-12'>
-        <h5>Stats</h5>
-        <ul>
-          <li>Servings: <%= @recipe.servings %></li>
-          <li>Prep Time: <%= display_time(@recipe.prep_time) %></li>
-          <li>Cook Time: <%= display_time(@recipe.cook_time) %></li>
-          <li>Total Time: <%= display_time(@recipe.total_time) %></li>
-          <li>Reheat Time: <%= display_time(@recipe.reheat_time) %></li>
-          <li>Prepared: <%= pluralize(@recipe.frequency, 'time') %></li>
-        </ul>
+       <h3>Ingredients</h3>
+        <div class='ml-3 mb-4'>
+          <% @recipe.ingredients.by_id.each do |ingredient| %>
+            <input type="checkbox">
+            <label class="mb-0 inline"><%= ingredient_display(ingredient) %></label><br>
+          <% end %>
+        </div>
       </div> <!-- col-6 -->
 
       <div class='col-md-6 col-sm-12'>
@@ -42,18 +47,49 @@
     </div> <!-- row -->
 
     <div class='row'>
-      <div class='col-12'>
-        <h3>Ingredients</h3>
-        <div class='ml-3 mb-4'>
-          <% @recipe.ingredients.by_id.each do |ingredient| %>
-            <input type="checkbox">
-            <label class="mb-0 inline"><%= ingredient_display(ingredient) %></label><br>
-          <% end %>
-        </div>
-      </div> <!-- col-12 -->
+      <div class='col-sm-12'>
+        <h3>Instructions</h3>
+        <div class="card mb-5">
+          <div class="card-header">
+            <ul class="nav nav-tabs card-header-tabs">
+              <li class="nav-item">
+                <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
+              </li>
+            </ul>
+          </div>
+          <div class="card-body">
+            <div class="tab-content" id="myTabContent">
+              <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
+                <ol>
+                  <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+                </ol>
+              </div>
+
+              <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
+                <ol>
+                  <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+                </ol>
+              </div>
+
+              <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
+                <ol>
+                  <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
+                </ol>
+              </div>
+            </div><!-- tab-content -->
+          </div><!-- card body -->
+        </div><!-- card -->
+      </div>
     </div> <!-- row -->
   </div> <!-- col-8 -->
 
+  <!-- Right side sidebar -->
   <div class='col-md-4 col-sm-12'>
     <div class='image-container mb-3'>
       <%= image_tag guaranteed_image(@recipe), { class: 'image' } %>
@@ -65,52 +101,8 @@
       <%= render partial: 'copy_for_user_form', locals: { recipe: @recipe } %>
       <%= render partial: 'related_recipes', locals: {recipe: @recipe} %>
     <% end %>
-  </div>
-</div> <!-- row -->
 
-<div class='row'>
-  <div class='col-md-8 col-sm-12'>
-    <h3>Instructions</h3>
-    <div class="card mb-5">
-      <div class="card-header">
-        <ul class="nav nav-tabs card-header-tabs">
-          <li class="nav-item">
-            <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
-          </li>
-        </ul>
-      </div>
-      <div class="card-body">
-        <div class="tab-content" id="myTabContent">
-          <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
-            <ol>
-              <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
-            </ol>
-          </div>
-
-          <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
-            <ol>
-              <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
-            </ol>
-          </div>
-
-          <div class="tab-pane fade" id="reheat" role="tabpanel" aria-labelledby="reheat-tab">
-            <ol>
-              <%= simple_format(@recipe.reheat_instructions, {}, wrapper_tag: 'li') %>
-            </ol>
-          </div>
-        </div><!-- tab-content -->
-      </div><!-- card body -->
-    </div><!-- card -->
-  </div> <!-- left column -->
-
-  <div class='col-md-4 col-sm-12'>
-    <h3>Nutrition Facts</h3>
+    <h3 class="mt-3">Nutrition Facts</h3>
     <%= render partial: 'nutritional_information', locals: { recipe: @recipe, iframe_parser: CronometerParser.new(@recipe.nutrition_data_iframe) } %>
-  </div> <!-- right column -->
+  </div>
 </div> <!-- row -->


### PR DESCRIPTION
## Problems Solved
* rearrange page elements to make more important things visible
* shrinks less-used stats into header
* i started messing around with my own styles instead of bootstrap, but will explore that in a separate PR
* allows us to see ingredients and instructions more easily 


## Screenshots
| Before | After |
|------|--------|
| <img width="1428" alt="Screen Shot 2023-12-27 at 10 05 18 AM" src="https://github.com/lortza/food_planner/assets/8680712/17e9aa88-d3e3-417a-a99f-97abbef6a9c9"> | <img width="1424" alt="Screen Shot 2023-12-27 at 10 05 35 AM" src="https://github.com/lortza/food_planner/assets/8680712/e48c974e-7c52-4e7f-980f-52b90334221a"> |
| <img width="701" alt="Screen Shot 2023-12-27 at 10 05 07 AM" src="https://github.com/lortza/food_planner/assets/8680712/fc06f022-d146-4a02-9a58-a86e4d6975b9"> | <img width="694" alt="Screen Shot 2023-12-27 at 10 04 30 AM" src="https://github.com/lortza/food_planner/assets/8680712/1bde29bb-4156-4cc1-8233-43e8ab342ec4">|


## Things Learned
* `.recipe-show-stats > * {` affects all child elements of this class


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
