### PR TITLE
Add permissions to action

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,7 +5,11 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     services:
       postgres:
         image: postgres:11-alpine

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
       # Add or replace dependency steps here
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@8f312efe1262fb463d906e9bf040319394c18d3e # v1.92
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:
           bundler-cache: true
       # Add or replace database setup steps here
@@ -47,6 +47,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           failedThreshold: 0
+        if: always()
       - name: Check Seeds
         run: bundle exec rake db:seed
 

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,11 +5,7 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@
 
 # Ignore Mac DS_Store files
 .DS_Store
-coverage
+coverage/*
+!coverage/.keep


### PR DESCRIPTION
## Problems Solved
I'm still trying to get the simplecov integration to work for dependabot PRs. I'm still not sure what's happening. I've tried:
* checking the repo workflow permissions
* adding (and then removing) SimpleCov to the branch protection rules
* following this blog post https://thewanderingcoder.com/2023/09/adding-github-actions-to-run-rspec-and-simplecov/
* investigating the `GITHUB_TOKEN` situation 
  * https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
  * https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
* this stackoverflow answer https://stackoverflow.com/a/70449620
* including the `coverage` directory, but gitignoring all files and folders in it

