### PR TITLE
Collapse danger zone

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -1,12 +1,6 @@
 @import 'variables';
 @import 'recipes';
 
-.footer--delete {
-  border-top: 1px solid $gray;
-  margin-top: 2rem;
-  padding-top: 1rem;
-}
-
 // Links
 a { color: $link-color; }
 

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -15,6 +15,7 @@
   display: inline;
   word-wrap: break-word;
 }
+.inline-block { display: inline-block; }
 
 // Input Sizes
 .checkbox-m { width: 25px; }

--- a/app/views/shared/_delete_footer.html.erb
+++ b/app/views/shared/_delete_footer.html.erb
@@ -1,5 +1,9 @@
-<footer class='footer--delete'>
-  <h5>Danger Zone</h5>
-  <p>Deleting this <%= object.class.name %> cannot be undone.</p>
-  <%= link_to "Delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: "#{button_classes('danger')} mb-5"  %>
-</footer>
+<details>
+  <summary class='mt-4 border-top border-secondary'><h5 class="inline-block pt-3">Danger Zone</h5></summary>
+  <footer>
+    <p>Deleting this <%= object.class.name %> cannot be undone.
+      <%= link_to "Delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>
+    </p>
+  </footer>
+</details>
+

--- a/app/views/shared/_delete_footer.html.erb
+++ b/app/views/shared/_delete_footer.html.erb
@@ -2,7 +2,7 @@
   <summary class='mt-4 border-top border-secondary'><h5 class="inline-block pt-3">Danger Zone</h5></summary>
   <footer>
     <p>Deleting this <%= object.class.name %> cannot be undone.
-      <%= link_to "Delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>
+      <%= link_to "Click to delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
     </p>
   </footer>
 </details>


### PR DESCRIPTION
## Related Issues & PRs
Closes #794

## Problems Solved
Makes the delete button harder to click on any given resource by moving it into a collapsed section.

## Things Learned
* Adding `display: inline-block;` will let you use a header tag as part of the `<summary>` tag.

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
