### PR TITLE
Fix bug when create meal plan fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Never open the `master.key` or `credentials.yml.enc` in atom. This will add newl
 
 To edit this file, run:
 ```
-EDITOR="atom --wait" bin/rails credentials:edit
+EDITOR="code --wait" bin/rails credentials:edit
 ```
 If this file gets borked, [this post](https://stackoverflow.com/a/54279636/5009528) and [this post](https://medium.com/@kirill_shevch/encrypted-secrets-credentials-in-rails-6-rails-5-1-5-2-f470accd62fc) will help.
 

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -23,7 +23,6 @@ class MealPlansController < ApplicationController
     }
     @meal_plan = current_user.meal_plans.new(default_params)
     authorize(@meal_plan)
-
     @recipes = current_user.recipes.includes(:meal_plan_recipes, :meal_plans).active.by_title
   end
 
@@ -44,6 +43,7 @@ class MealPlansController < ApplicationController
     if @meal_plan.save
       redirect_to meal_plan_url(@meal_plan)
     else
+      @recipes = current_user.recipes.includes(:meal_plan_recipes, :meal_plans).active.by_title
       render :new
     end
   end
@@ -51,7 +51,6 @@ class MealPlansController < ApplicationController
   def edit
     authorize(@meal_plan)
     @recipes = current_user.recipes.includes(:meal_plan_recipes, :meal_plans).active.by_title
-
   end
 
   def update
@@ -60,6 +59,7 @@ class MealPlansController < ApplicationController
     if @meal_plan.update(meal_plan_params)
       redirect_to meal_plan_url(@meal_plan), notice: "#{@meal_plan.prepared_on} Meal Plan Updated"
     else
+      @recipes = current_user.recipes.includes(:meal_plan_recipes, :meal_plans).active.by_title
       render :edit
     end
   end

--- a/app/views/meal_plans/_form.html.erb
+++ b/app/views/meal_plans/_form.html.erb
@@ -27,7 +27,7 @@
       <div class="col-sm-3">Select Recipes</div>
 
       <div class="col-sm-9">
-        <%= form.collection_check_boxes :recipe_ids, @recipes, :id, :title do |r| %>
+        <%= form.collection_check_boxes :recipe_ids, recipes, :id, :title do |r| %>
           <div class='form-check'>
             <%= r.check_box class: 'form-check-input' %>
             <%= r.label class: 'form-check-label' do %>

--- a/app/views/meal_plans/edit.html.erb
+++ b/app/views/meal_plans/edit.html.erb
@@ -4,6 +4,6 @@
 
 <h1>Edit the Plan for <%= @meal_plan.prepared_on.to_fs(:long) %> </h1>
 
-<%= render 'form', meal_plan: @meal_plan %>
+<%= render partial: 'form', locals: { meal_plan: @meal_plan, recipes: @recipes } %>
 
 <%= render partial: 'shared/delete_footer', locals: { object: @meal_plan, delete_path: @meal_plan } %>

--- a/app/views/meal_plans/new.html.erb
+++ b/app/views/meal_plans/new.html.erb
@@ -4,4 +4,4 @@
 
 <h1>Create a Meal Plan</h1>
 
-<%= render 'form', meal_plan: @meal_plan %>
+<%= render partial: 'form', locals: { meal_plan: @meal_plan, recipes: @recipes } %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ end
 
 
 RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -86,20 +86,55 @@ RSpec.describe 'MealPlans', type: :request do
       expect(response).to render_template(:edit)
     end
 
-    xit 'renders meal_plans#create' do
-      starting_count = MealPlan.count
-      meal_plan_attributes = build(:meal_plan, user: user).attributes
-      post meal_plans_path(meal_plan: meal_plan_attributes)
+    describe '#create' do
+      context 'when the save is successful' do
+        it 'creates a new record' do
+          starting_count = MealPlan.count
+          meal_plan_attributes = build(:meal_plan, user: user).attributes
+          post meal_plans_path(meal_plan: meal_plan_attributes)
 
-      expect(response).to be_successful
-      expect(MealPlan.count).to eq(starting_count + 1)
+          expect(MealPlan.count).to eq(starting_count + 1)
+        end
+
+        it 'redirects to the new record' do
+          meal_plan_attributes = build(:meal_plan, user: user).attributes
+          post meal_plans_path(meal_plan: meal_plan_attributes)
+
+          expect(response).to redirect_to meal_plan_url(user.meal_plans.last)
+        end
+      end
+
+      context 'when the save is unsuccessful' do
+        it 'renders :new' do
+          same_date = '2024-04-01'
+          existing_meal_plan = create(:meal_plan, prepared_on: same_date, user: user)
+          meal_plan_attributes = build(:meal_plan, prepared_on: same_date, user: user).attributes
+          post meal_plans_path(meal_plan: meal_plan_attributes)
+
+          expect(response).to render_template(:new)
+        end
+      end
     end
 
-    it 'renders meal_plans#update' do
-      new_prepared_on = Time.zone.now + 15
-      patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: new_prepared_on })
+    describe '#update' do
+      context 'when the update is successful' do
+        it 'redirects to the meal_plan' do
+          new_prepared_on = Time.zone.now + 15
+          patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: new_prepared_on })
 
-      expect(response).to redirect_to meal_plan_url(user_meal_plan)
+          expect(response).to redirect_to meal_plan_url(user_meal_plan)
+        end
+      end
+
+      context 'when the update is unsuccessful' do
+        it 'redirects to the meal_plan' do
+          same_date = '2024-04-01'
+          existing_meal_plan = create(:meal_plan, prepared_on: same_date, user: user)
+          patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: same_date })
+
+          expect(response).to render_template(:edit)
+        end
+      end
     end
 
     it 'renders meal_plans#destroy' do


### PR DESCRIPTION
## Related Issues & PRs
Closes [Sentry issue](https://anne-richardson.sentry.io/issues/5240185950/?referrer=alert_email&alert_type=email&alert_timestamp=1713825211748&alert_rule_id=1078349&notification_uuid=a1ab9cc7-a1f7-487f-81dd-fd23a696d7fb&environment=production)

## Problems Solved
* Fixes bug where meal_plan create has no error handling
* Fixes bug where meal_plan edit has no error handling

## Screenshots
<img width="706" alt="Screenshot 2024-04-22 at 7 22 11 PM" src="https://github.com/lortza/food_planner/assets/8680712/82847f6b-3435-4f08-b1d7-9be652008bc4">


## Things Learned
* somehow, i got away with not having values for the second instance variable in my `:create` and `:update` actions when the form could not submit properly
* oddly enough, i am sure i've bumped into errors on these forms before and never got the application bork message
* but the question remains: how did this ever work? neat. fun to encounter when trying to do food planning for the week.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
