### PR TITLE
Enable user edit of password

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,10 +1,11 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%= link_to "Back", :back, class: "#{button_classes('info')} float-right" %>
+<h1>Edit <%= resource_name.to_s.humanize %></h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= devise_error_messages! %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, class: 'font-weight-bold' %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
@@ -12,32 +13,29 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+  <div class="field mt-4">
+    <%= f.label 'New Password', class: 'font-weight-bold' %> <i class='text-muted'>(leave blank if you don't want to change it)</i><br />
     <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em class='form-text text-muted'><%= @minimum_password_length %> characters minimum</em>
     <% end %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
+  <div class="field mt-4">
+    <%= f.label 'Confirm New Password', class: 'font-weight-bold' %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+  <div class="field mt-4">
+    <%= f.label :current_password, class: 'font-weight-bold' %> <i class='text-muted'>(we need your current password to confirm your changes)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 
-  <div class="actions">
-    <%= f.submit 'Update', class: 'btn btn-primary' %>
+  <div class="actions mt-4">
+    <%= f.submit "Update", class: button_classes('success') %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<hr>
+<h4>Cancel my account</h4>
+<p>Unhappy? <%= button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: button_classes('danger') %></p>

--- a/app/views/shared/navbar/_main.html.erb
+++ b/app/views/shared/navbar/_main.html.erb
@@ -6,10 +6,11 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
-      <%= render 'shared/navbar/signed_in' if current_user %>
-      <li class="nav-item">
-        <%= session_links %>
-      </li>
+      <% if current_user.present? %>
+        <%= render 'shared/navbar/signed_in' %>
+      <% else %>
+        <li class="nav-item"><%= session_links %></li>
+      <% end %>
     </ul>
     <%= render 'shared/navbar/search' if current_user %>
   </div>

--- a/app/views/shared/navbar/_signed_in.html.erb
+++ b/app/views/shared/navbar/_signed_in.html.erb
@@ -34,3 +34,13 @@
     <%= link_to 'Inventory', edit_inventory_path(current_user.inventory.id), class: 'dropdown-item' if current_user.inventory.present? %>
   </div>
 </li>
+
+<li class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= current_user.email %>
+  </a>
+  <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+    <%= link_to 'Change My Password', edit_user_registration_path, class: 'dropdown-item' %>
+    <%= link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
+  </div>
+</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'shopping_lists#show'
 
-  # Skip registrations for now so no new users can sign up.
-  devise_for :users, skip: [:registrations]
+  # Clobber sign_up for now so no new users can sign up.
+  devise_for :users, path_names: {
+    sign_up: ''
+  }
 
   # When we do want to allow new users to sign up, we need to override the
   # devise registrations controller so that we can run custom UserDataSetup


### PR DESCRIPTION
## Problems Solved
* Allows a user to edit their password via web gui

<img width="904" alt="Screenshot 2024-05-14 at 7 18 44 PM" src="https://github.com/lortza/food_planner/assets/8680712/463c2ab7-2101-465a-9d37-4e5918914d62">


## Things Learned
* You can clobber out specific devise routes

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
