### PR TITLE
Prioritize prep day

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -107,11 +107,6 @@
       </table>
     </div>
 
-    <div class="field">
-      <%= form.label 'Instructions', class: 'font-weight-bold mt-5' %>
-      <%= form.text_area :instructions, class: 'form-control instructions' %>
-    </div>
-
     <div class="row">
       <div class="col-lg-6 col-md-12">
         <div class="field">
@@ -127,6 +122,11 @@
         </div>
       </div>
     </div><!-- row -->
+
+    <div class="field">
+      <%= form.label 'Original Instructions', class: 'font-weight-bold mt-5' %>
+      <%= form.text_area :instructions, class: 'form-control instructions' %>
+    </div>
 
     <%= form.submit class: button_classes('primary mt-3') %>
   <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -53,27 +53,27 @@
           <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs">
               <li class="nav-item">
-                <a class="nav-link active" id="home-tab" data-toggle="tab" href="#regular" role="tab" aria-controls="regular" aria-selected="true">Regular</a>
+                <a class="nav-link active" id="prep-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" id="profile-tab" data-toggle="tab" href="#prep-day" role="tab" aria-controls="prep-day" aria-selected="false">Prep Day</a>
+                <a class="nav-link" id="original-tab" data-toggle="tab" href="#original" role="tab" aria-controls="original" aria-selected="true">Original</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" id="contact-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
+                <a class="nav-link" id="reheat-tab" data-toggle="tab" href="#reheat" role="tab" aria-controls="reheat" aria-selected="false">Reheat</a>
               </li>
             </ul>
           </div>
           <div class="card-body">
             <div class="tab-content" id="myTabContent">
-              <div class="tab-pane fade show active" id="regular" role="tabpanel" aria-labelledby="regular-tab">
+              <div class="tab-pane fade show active" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
                 <ol>
-                  <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
+                  <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
                 </ol>
               </div>
 
-              <div class="tab-pane fade" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
+              <div class="tab-pane fade" id="original" role="tabpanel" aria-labelledby="original-tab">
                 <ol>
-                  <%= simple_format(@recipe.prep_day_instructions, {}, wrapper_tag: 'li') %>
+                  <%= simple_format(@recipe.instructions, {}, wrapper_tag: 'li') %>
                 </ol>
               </div>
 

--- a/lib/tasks/recipe_tasks.rake
+++ b/lib/tasks/recipe_tasks.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :recipes do
+  desc "Backfill prep_day_instructions"
+  task backfill_prep_day_instructions: :environment do
+    ActiveRecord::Base.transaction do
+      puts 'Backfilling all prep_day_instructions with instructions values'
+      # There are 218 Records in production, so the poor perfomance of this each loop is not an issue.
+      Recipe.all.each do |recipe|
+        next if recipe.prep_day_instructions.blank? && recipe.instructions.blank?
+        next if recipe.prep_day_instructions.present? && recipe.instructions.present?
+
+        recipe.update!(prep_day_instructions: recipe.instructions) if recipe.prep_day_instructions.blank?
+        recipe.update!(instructions: recipe.prep_day_instructions) if recipe.instructions.blank?
+      end
+    end
+  end
+end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     user
     sequence(:title) { |n| "Recipe Title #{n}" }
     sequence(:source_name) { |n| "Recipe Source #{n}" }
-    sequence(:source_url) { |n| "http://recipesource#{n}.com" }
+    sequence(:source_url) { |n| "https://example#{n}.com" }
     prep_time { rand(0..20) }
     nutrition_data_iframe { '' }
     cook_time { rand(0..60) }


### PR DESCRIPTION
## Problems Solved
* prioritizes prep day content on recipe show page by swapping tab location
* prioritizes prep day content in recipe form by moving fields to make prep day & reheat first
* backfills prod data so prep day is not empty
* adds validations so prep day is not empty
* handles case where user forgets to fill in original recipe upon create

## Screenshots
<img width="767" alt="Screenshot 2024-11-10 at 11 57 18 AM" src="https://github.com/user-attachments/assets/65d2a270-56ba-4dee-8a18-49409a0230e0">

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
