### PR TITLE
Switch specs files to standardrb formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,74 +1,74 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby File.read('.ruby-version').strip
-gem 'rails', '~> 7.2.1'         # Updates to the latest patch that's lower than 7.2
+ruby File.read(".ruby-version").strip
+gem "rails", "~> 7.2.1"         # Updates to the latest patch that's lower than 7.2
 
-gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'coffee-rails'              # Use CoffeeScript for .coffee assets and views
-gem 'devise'                    # User authentication
-gem 'jbuilder', '~> 2.12'       # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'loofah', '>= 2.2.3'        # Upgrade for security update
-gem 'nokogiri', '>= 1.8.5'      # Upgrade for security update
-gem 'pg', '>= 0.18', '< 2.0'
-gem 'puma'                      # Use Puma as the app server
-gem 'pundit'                    # Authorization
-gem 'rack', '>= 2.0.6'          # Upgrade for security update
-gem 'sass-rails', '~> 6.0'      # Use SCSS for stylesheets
-gem 'sentry-rails'              # Rails support for Sentry
-gem 'sentry-ruby'               # Error reporting to Sentry.io
-gem 'will_paginate', '~> 4.0.1' # pagination. Styles: http://mislav.github.io/will_paginate/
+gem "bootsnap", ">= 1.1.0", require: false # Reduces boot times through caching; required in config/boot.rb
+gem "coffee-rails"              # Use CoffeeScript for .coffee assets and views
+gem "devise"                    # User authentication
+gem "jbuilder", "~> 2.12"       # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem "loofah", ">= 2.2.3"        # Upgrade for security update
+gem "nokogiri", ">= 1.8.5"      # Upgrade for security update
+gem "pg", ">= 0.18", "< 2.0"
+gem "puma"                      # Use Puma as the app server
+gem "pundit"                    # Authorization
+gem "rack", ">= 2.0.6"          # Upgrade for security update
+gem "sass-rails", "~> 6.0"      # Use SCSS for stylesheets
+gem "sentry-rails"              # Rails support for Sentry
+gem "sentry-ruby"               # Error reporting to Sentry.io
+gem "will_paginate", "~> 4.0.1" # pagination. Styles: http://mislav.github.io/will_paginate/
 # gem 'redis', '~> 4.0'           # Use Redis adapter to run Action Cable in production
-# gem 'mini_magick', '~> 4.8'  # Use ActiveStorage variant
+# gem 'mini_magick', '~> 4.8'     # Use ActiveStorage variant
 # gem 'capistrano-rails', group: :development # Use Capistrano for deployment
-gem 'net-smtp', require: false  # Send internet mail via SMTP
-gem 'net-pop', require: false
-gem 'net-imap', require: false
+gem "net-imap", require: false
+gem "net-pop", require: false
+gem "net-smtp", require: false  # Send internet mail via SMTP
 
 group :development do
-  gem 'annotate'
-  gem 'awesome_print'
-  gem 'bullet'                  # detects n+1 queries
-  gem 'listen'
+  gem "annotate"
+  gem "awesome_print"
+  gem "bullet"                      # detects n+1 queries
+  gem "listen"
   # gem 'magic_frozen_string_literal'
-  gem 'rails-erd', require: false   # generates table diagram run `bundle exec erd`
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
-  gem 'rubycritic', require: false  # provides stats on code build
-  gem 'scss_lint', require: false # css linter
-  gem 'seed_dump' # invoke with `rake db:seed:dump`
+  gem "rails-erd", require: false   # generates table diagram run `bundle exec erd`
+  gem "standard"                    # standard rb code linter
+  # gem 'rubocop-performance'
+  # gem 'rubocop-rails'
+  gem "rubycritic", require: false  # provides stats on code build
+  gem "scss_lint", require: false   # css linter
+  gem "seed_dump"                   # invoke with `rake db:seed:dump`
   # Spring speeds up development by keeping your application running
   # in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.1.0'
-  gem 'standard'                # standard rb code linter
-  gem 'web-console', '>= 3.3.0' # Access an IRB console by using <%= console %> anywhere in the code.
+  gem "spring"
+  gem "spring-watcher-listen", "~> 2.1.0"
+  gem "web-console", ">= 3.3.0"     # Access an IRB console by using <%= console %> anywhere in the code.
 end
 
 group :development, :test do
-  gem 'rspec-rails', '~> 7.1.0'
-  gem 'better_errors'           # creates console in browser for errors
-  gem 'binding_of_caller'       # goes with better_errors
-  gem 'byebug', platforms: %i[mri mingw x64_mingw] # Call 'byebug' anywhere in the code to get a debugger console
-  gem 'factory_bot_rails'       # factory support for rspec
-  gem 'faker'                   # Fake data for factories
-  gem 'guard-rspec', require: false # runs rspec automatically
-  gem 'pry-rails'               # helps with pry
-  gem 'reek'                    # https://github.com/troessner/reek/blob/master/docs/Code-Smells.md
-  gem 'selenium-webdriver'
-  gem 'webdrivers', '5.3.1'   # to help with testing
+  gem "better_errors"           # creates console in browser for errors
+  gem "binding_of_caller"       # goes with better_errors
+  gem "byebug", platforms: %i[mri mingw x64_mingw] # Call 'byebug' anywhere in the code to get a debugger console
+  gem "factory_bot_rails"       # factory support for rspec
+  gem "faker"                   # Fake data for factories
+  gem "guard-rspec", require: false # runs rspec automatically
+  gem "pry-rails"               # helps with pry
+  gem "reek"                    # https://github.com/troessner/reek/blob/master/docs/Code-Smells.md
+  gem "rspec-rails", "~> 7.1.0"
+  gem "selenium-webdriver"
+  gem "webdrivers", "5.3.1"     # to help with testing
 end
 
 group :test do
-  gem 'capybara'                # for navigating feature specs
+  gem "capybara"                  # for navigating feature specs
   # gem 'database_cleaner-active_record'
-  gem 'launchy' # open browser with save_and_open_page
-  gem 'rails-controller-testing' # allows for controller testing
-  gem 'shoulda-matchers' # library for easier testing syntax
-  gem 'simplecov' # using to display rspec coverage in PR comment
+  gem "launchy"                   # open browser with save_and_open_page
+  gem "rails-controller-testing"  # allows for controller testing
+  gem "shoulda-matchers"          # library for easier testing syntax
+  gem "simplecov"                 # using to display rspec coverage in PR comment
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     flay (2.13.3)
@@ -248,6 +249,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
@@ -376,11 +379,6 @@ GEM
     rubocop-performance (1.22.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails (2.27.0)
-      activesupport (>= 4.2.0)
-      rack (>= 1.1)
-      rubocop (>= 1.52.0, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
@@ -500,6 +498,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
@@ -536,8 +535,6 @@ DEPENDENCIES
   rails-erd
   reek
   rspec-rails (~> 7.1.0)
-  rubocop-performance
-  rubocop-rails
   rubycritic
   sass-rails (~> 6.0)
   scss_lint

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Live on heroku as [myfoodplanner](http://myfoodplanner.herokuapp.com)
 * Ruby
 * Rails
 * Postgres
-* RuboCop
+* [Standard (Ruby)](https://github.com/standardrb/standard), which supports the [VSCode extension](https://github.com/standardrb/vscode-standard-ruby)
 * RSpec
 * [Bootstrap 4.1.3](https://getbootstrap.com/docs/4.6/getting-started/introduction/)
 * [Material Icons](https://fonts.google.com/icons)
@@ -47,9 +47,11 @@ Run them locally on your machine like this:
 ```
 bundle exec reek
 
-bundle exec rubocop
-
 bundle exec scss-lint app/assets/stylesheets/**.scss
+
+standardrb --fix
+# or
+rake standard:fix
 ```
 
 ## Related Docs

--- a/spec/db/seeds_helper_spec.rb
+++ b/spec/db/seeds_helper_spec.rb
@@ -1,77 +1,77 @@
 # frozen_string_literal: true
 
-require Rails.root.join('db/seeds_helper.rb')
+require Rails.root.join("db/seeds_helper.rb")
 
-RSpec.describe 'SeedsHelper' do
+RSpec.describe "SeedsHelper" do
   let(:seeds_helper) { Class.new { include SeedsHelper }.new }
   let(:user) { create(:user) }
   let(:recipe_data) do
     [{
       title: "Veggie Po'boy",
-      source_name: 'Warm Kitchen',
-      source_url: 'https://warmkitchen.wordpress.com/2014/11/12/its-a-veggie-po-boy-yall/',
+      source_name: "Warm Kitchen",
+      source_url: "https://warmkitchen.wordpress.com/2014/11/12/its-a-veggie-po-boy-yall/",
       servings: 4,
-      instructions: 'Cook stuff',
+      instructions: "Cook stuff",
       prep_time: 10,
       cook_time: 20,
-      image_url: 'http://cdn2.pepperplate.com/recipes/bcb751ba9ab749dbb0f48ffb083a72c5.jpg',
+      image_url: "http://cdn2.pepperplate.com/recipes/bcb751ba9ab749dbb0f48ffb083a72c5.jpg",
       reheat_time: 20,
-      pepperplate_url: 'http://www.pepperplate.com/recipes/view.aspx?id=15454393',
+      pepperplate_url: "http://www.pepperplate.com/recipes/view.aspx?id=15454393",
       archived: false
     },
-     {
-       title: 'Quick Pad Thai',
-       source_name: "Women's Health Magazine",
-       source_url: 'https://subscribe.hearstmags.com/circulation/shared/index.html',
-       servings: 4,
-       instructions: 'Cook stuff',
-       prep_time: 10,
-       cook_time: 20,
-       image_url: 'http://cdn2.pepperplate.com/recipes/dad9e72fa23f4e839c6057b8684da88e.jpg',
-       reheat_time: 10,
-       pepperplate_url: 'http://www.pepperplate.com/recipes/view.aspx?id=15772038',
-       archived: false
-     },]
+      {
+        title: "Quick Pad Thai",
+        source_name: "Women's Health Magazine",
+        source_url: "https://subscribe.hearstmags.com/circulation/shared/index.html",
+        servings: 4,
+        instructions: "Cook stuff",
+        prep_time: 10,
+        cook_time: 20,
+        image_url: "http://cdn2.pepperplate.com/recipes/dad9e72fa23f4e839c6057b8684da88e.jpg",
+        reheat_time: 10,
+        pepperplate_url: "http://www.pepperplate.com/recipes/view.aspx?id=15772038",
+        archived: false
+      }]
   end
   let(:ingredient_data) do
     [{
       recipe_title: "Veggie Po'boy",
       quantity: 8.0,
-      measurement_unit: 'slice',
-      name: 'muenster cheese',
-      preparation_style: 'sliced'
+      measurement_unit: "slice",
+      name: "muenster cheese",
+      preparation_style: "sliced"
     },
-     {
-       recipe_title: 'Quick Pad Thai',
-       quantity: 1.0,
-       measurement_unit: 'cup',
-       name: 'cucumber',
-       preparation_style: 'sliced'
-     },]
+      {
+        recipe_title: "Quick Pad Thai",
+        quantity: 1.0,
+        measurement_unit: "cup",
+        name: "cucumber",
+        preparation_style: "sliced"
+      }]
   end
 
-  describe '#check_for_existing_data!' do
+  describe "#check_for_existing_data!" do
     subject(:check_for_existing_data!) { seeds_helper.check_for_existing_data! }
 
-    context 'when no data exists' do
+    context "when no data exists" do
       it { expect { check_for_existing_data! }.not_to raise_error }
     end
 
-    context 'when data already exists' do
+    context "when data already exists" do
       before { create(:user) }
-      it { expect { check_for_existing_data! }.to raise_error('ExistingDataError') }
+      it { expect { check_for_existing_data! }.to raise_error("ExistingDataError") }
     end
   end
 
-  describe '#assign_user_to_seed_data' do
+  describe "#assign_user_to_seed_data" do
     subject(:processed_data) { seeds_helper.assign_user_to_seed_data(recipe_data, user) }
-    it 'assigns user' do
+    it "assigns user" do
       expect(recipe_data.first[:user]).to be nil
       expect(processed_data.first[:user]).to eq(user)
     end
   end
 
-  describe '#build_recipe_title_id_hash' do
+  describe "#build_recipe_title_id_hash" do
     let!(:recipe) { create(:recipe, title: recipe_data.first[:title]) }
     let(:expected_hash) do
       {
@@ -81,39 +81,39 @@ RSpec.describe 'SeedsHelper' do
     end
     subject(:recipe_title_id_hash) { seeds_helper.build_recipe_title_id_hash(ingredient_data) }
 
-    it 'returns a hash with recipe title as key and recipe id as value' do
+    it "returns a hash with recipe title as key and recipe id as value" do
       expect(recipe_title_id_hash).to eq(expected_hash)
     end
   end
 
-  describe '#notify_if_missing_recipes' do
+  describe "#notify_if_missing_recipes" do
     let(:recipe_hash) { seeds_helper.build_recipe_title_id_hash(ingredient_data) }
     subject(:notifiy) { seeds_helper.notify_if_missing_recipes(ingredient_data, recipe_hash) }
 
-    context 'with missing recipe' do
-      it 'outputs notification if any ingredient is missing a matching recipe' do
+    context "with missing recipe" do
+      it "outputs notification if any ingredient is missing a matching recipe" do
         expect($stdout).to receive(:puts).with(SeedsHelper::MISSING_RECIPE_WARNING)
         notifiy
       end
     end
 
-    context 'without missing recipe' do
+    context "without missing recipe" do
       before do
         recipe_data.each { |recipe| create(:recipe, title: recipe[:title]) }
       end
-      it 'does not output a message' do
+      it "does not output a message" do
         expect($stdout).not_to receive(:puts)
         notifiy
       end
     end
   end
 
-  describe '#assign_recipe_to_seed_data' do
+  describe "#assign_recipe_to_seed_data" do
     let!(:recipe) { create(:recipe, title: recipe_data.first[:title]) }
-    let(:recipe_title_id_hash) { { recipe.title => recipe.id } }
+    let(:recipe_title_id_hash) { {recipe.title => recipe.id} }
     subject(:processed_data) { seeds_helper.assign_recipe_to_seed_data(ingredient_data, recipe_title_id_hash) }
 
-    it 'assigns recipe_id' do
+    it "assigns recipe_id" do
       expect(processed_data.first[:recipe_id]).to eq(recipe.id)
     end
   end

--- a/spec/factories/experimental_recipes.rb
+++ b/spec/factories/experimental_recipes.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
 
     trait :with_faker_data do
       title { Faker::Food.dish }
-      image_url { 'https://placehold.co/400x400' }
+      image_url { "https://placehold.co/400x400" }
     end
   end
 end

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     recipe { association(:recipe) }
     sequence(:name) { |n| "ingredient name #{n}" }
     quantity { (0.25..3).step(0.25).to_a.sample }
-    measurement_unit { Ingredient::UNITS[1..-1].sample }
+    measurement_unit { Ingredient::UNITS[1..].sample }
 
     trait :with_faker_data do
       name { Faker::Food.ingredient }

--- a/spec/factories/meal_plans.rb
+++ b/spec/factories/meal_plans.rb
@@ -25,6 +25,6 @@ FactoryBot.define do
     user
     prepared_on { rand((Time.zone.today - 10)...Time.zone.today) }
     people_served { 2 }
-    notes { '' }
+    notes { "" }
   end
 end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
     sequence(:source_name) { |n| "Recipe Source #{n}" }
     sequence(:source_url) { |n| "https://example#{n}.com" }
     prep_time { rand(0..20) }
-    nutrition_data_iframe { '' }
+    nutrition_data_iframe { "" }
     cook_time { rand(0..60) }
     reheat_time { rand(0..60) }
     servings { rand(1..10) }
@@ -49,26 +49,25 @@ FactoryBot.define do
     prep_day_instructions { Faker::Hipster.sentences(number: 8).join("\n\n") }
     reheat_instructions { Faker::Lorem.sentences(number: 4).join("\n\n") }
 
-
     trait :db_default do
-      title { '' }
-      source_name { '' }
-      source_url { '' }
+      title { "" }
+      source_name { "" }
+      source_url { "" }
       servings { 0 }
-      instructions { '' }
+      instructions { "" }
       prep_time { 0 }
       cook_time { 0 }
-      image_url { '' }
-      reheat_time { '' }
+      image_url { "" }
+      reheat_time { "" }
       archived { false }
-      prep_day_instructions { '' }
-      reheat_instructions { '' }
+      prep_day_instructions { "" }
+      reheat_instructions { "" }
     end
 
     trait :with_faker_data do
       sequence(:title) { |n| "#{Faker::Food.dish} #{n}" }
       source_name { Faker::Restaurant.name }
-      image_url { ['', 'https://picsum.photos/400/400', 'https://picsum.photos/450/450', 'https://loremflickr.com/500/500', 'https://loremflickr.com/500/500/food,dessert,drink,dinner,lunch/all', 'https://loremflickr.com/400/400/food,dessert,drink,dinner,lunch/all'].sample }
+      image_url { ["", "https://picsum.photos/400/400", "https://picsum.photos/450/450", "https://loremflickr.com/500/500", "https://loremflickr.com/500/500/food,dessert,drink,dinner,lunch/all", "https://loremflickr.com/400/400/food,dessert,drink,dinner,lunch/all"].sample }
     end
 
     # This allow you to pass in the number of ingredients you want to build. Ex:

--- a/spec/factories/shopping_list_items.rb
+++ b/spec/factories/shopping_list_items.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
     aisle_id { create(:aisle).id }
     sequence(:name) { |n| "List Item Name #{n}" }
     quantity { 1 }
-    heb_upc { '1234' }
-    status { 'active' }
+    heb_upc { "1234" }
+    status { "active" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,8 +22,8 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@email.com" }
-    password { 'password' }
-    password_confirmation { 'password' }
+    password { "password" }
+    password_confirmation { "password" }
 
     trait :admin do
       admin { true }

--- a/spec/features/convert_experimental_to_recipe.rb
+++ b/spec/features/convert_experimental_to_recipe.rb
@@ -1,43 +1,43 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'User converts an experimental recipe to a recipe', type: :feature do
+describe "User converts an experimental recipe to a recipe", type: :feature do
   let(:user) { create(:user) }
   let(:experimental_recipe) { create(:experimental_recipe, user: user) }
 
   before do
     experimental_recipe
 
-    visit '/users/sign_in'
-    within('#new_user') do
-      fill_in 'Email', with: user.email
-      fill_in 'Password', with: user.password
+    visit "/users/sign_in"
+    within("#new_user") do
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
     end
-    click_button 'Log in'
+    click_button "Log in"
 
     visit(experimental_recipes_path)
-    click_link('convert to recipe')
+    click_link("convert to recipe")
   end
 
-  it 'populates a new recipe with existing data' do
-    expect(page).to have_content('Create a Recipe')
-    expect(page).to have_field('Title', with: experimental_recipe.title)
-    expect(page).to have_field('Source url', with: experimental_recipe.source_url)
+  it "populates a new recipe with existing data" do
+    expect(page).to have_content("Create a Recipe")
+    expect(page).to have_field("Title", with: experimental_recipe.title)
+    expect(page).to have_field("Source url", with: experimental_recipe.source_url)
   end
 
-  it 'Experimenal recipe is deleted after new recipe is saved' do
-    fill_in 'Servings', with: '4'
-    fill_in 'recipe_prep_time', with: '20'
-    fill_in 'recipe_cook_time', with: '20'
-    fill_in 'recipe_image_url', with: 'recipe_placeholder.jpg'
-    find('#recipe_ingredients_attributes_0_quantity').set('1')
-    find('#recipe_ingredients_attributes_0_quantity').set('1')
-    select 'cup', from: 'recipe_ingredients_attributes_0_measurement_unit'
-    find('#recipe_ingredients_attributes_0_name').set('water')
-    find('#recipe_instructions').set('Lorem ipsum')
+  it "Experimenal recipe is deleted after new recipe is saved" do
+    fill_in "Servings", with: "4"
+    fill_in "recipe_prep_time", with: "20"
+    fill_in "recipe_cook_time", with: "20"
+    fill_in "recipe_image_url", with: "recipe_placeholder.jpg"
+    find("#recipe_ingredients_attributes_0_quantity").set("1")
+    find("#recipe_ingredients_attributes_0_quantity").set("1")
+    select "cup", from: "recipe_ingredients_attributes_0_measurement_unit"
+    find("#recipe_ingredients_attributes_0_name").set("water")
+    find("#recipe_instructions").set("Lorem ipsum")
 
-    click_button('Create Recipe')
+    click_button("Create Recipe")
     expect(page).to have_content(experimental_recipe.title)
 
     visit(experimental_recipes_path)

--- a/spec/features/recipes_show_page_authorization.rb
+++ b/spec/features/recipes_show_page_authorization.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.feature 'Recipes Show page viewable by user role', type: :feature do
+RSpec.feature "Recipes Show page viewable by user role", type: :feature do
   let!(:author) { create(:user) }
   let!(:other_user) { create(:user) }
   let!(:author_recipe) { create(:recipe, user: author) }
@@ -12,73 +12,73 @@ RSpec.feature 'Recipes Show page viewable by user role', type: :feature do
   let!(:other_user_meal_plan) { create(:meal_plan, user: other_user, prepared_on: Time.zone.now + 10) }
   let!(:other_user_meal_plan_recipe) { create(:meal_plan_recipe, meal_plan: other_user_meal_plan) }
 
-  describe 'recipes viewable without authentication and by non-authors' do
+  describe "recipes viewable without authentication and by non-authors" do
     before do
-      visit '/users/sign_in'
-      within('#new_user') do
-        fill_in 'Email', with: other_user.email
-        fill_in 'Password', with: other_user.password
+      visit "/users/sign_in"
+      within("#new_user") do
+        fill_in "Email", with: other_user.email
+        fill_in "Password", with: other_user.password
       end
-      click_button 'Log in'
+      click_button "Log in"
     end
 
-    context 'show page' do
-      it 'does not show the meal plans' do
+    context "show page" do
+      it "does not show the meal plans" do
         visit "/recipes/#{author_recipe.id}"
 
-        expect(page).to_not have_content 'Related Meal Plans'
-        expect(page).to_not have_content 'Add to Upcoming Plans'
+        expect(page).to_not have_content "Related Meal Plans"
+        expect(page).to_not have_content "Add to Upcoming Plans"
       end
 
-      it 'does not show the edit button' do
+      it "does not show the edit button" do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to_not have_content 'Edit'
+        expect(page).to_not have_content "Edit"
       end
 
       it 'does not show the "add to shopping list" feature' do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to_not have_content 'Add Ingredients to List'
+        expect(page).to_not have_content "Add Ingredients to List"
       end
 
       it 'does not show the "copy for user" feature' do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to_not have_content 'Copy Recipe for User'
+        expect(page).to_not have_content "Copy Recipe for User"
       end
     end
   end
 
-  describe 'recipes viewable by author' do
+  describe "recipes viewable by author" do
     before do
-      visit '/users/sign_in'
-      within('#new_user') do
-        fill_in 'Email', with: author.email
-        fill_in 'Password', with: author.password
+      visit "/users/sign_in"
+      within("#new_user") do
+        fill_in "Email", with: author.email
+        fill_in "Password", with: author.password
       end
-      click_button 'Log in'
+      click_button "Log in"
     end
 
-    context 'show page' do
-      it 'displays the meal plans' do
+    context "show page" do
+      it "displays the meal plans" do
         create(:meal_plan, user: author)
         visit "/recipes/#{author_recipe.id}"
 
-        expect(page).to have_content 'Related Meal Plans'
-        expect(page).to have_content 'Add to Upcoming Plans'
+        expect(page).to have_content "Related Meal Plans"
+        expect(page).to have_content "Add to Upcoming Plans"
       end
 
-      it 'displays the edit button' do
+      it "displays the edit button" do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to have_content 'Edit'
+        expect(page).to have_content "Edit"
       end
 
       it 'displays the "add to shopping list" feature' do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to have_content 'Add Ingredients to List'
+        expect(page).to have_content "Add Ingredients to List"
       end
 
       it 'displays the "copy for user" feature' do
         visit "/recipes/#{author_recipe.id}"
-        expect(page).to_not have_content 'Copy Recipe for User'
+        expect(page).to_not have_content "Copy Recipe for User"
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,77 +1,77 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe 'session_links' do
-    describe 'when a user is logged in' do
+  describe "session_links" do
+    describe "when a user is logged in" do
       let(:current_user) { create(:user) }
 
-      it 'it shows a link to sign out' do
-        expect(session_links).to include('Sign Out')
+      it "it shows a link to sign out" do
+        expect(session_links).to include("Sign Out")
       end
     end
 
-    describe 'there is no current user session' do
+    describe "there is no current user session" do
       let(:current_user) { nil }
 
-      it 'shows a link to sign in' do
-       expect(session_links).to include('Sign In')
+      it "shows a link to sign in" do
+        expect(session_links).to include("Sign In")
       end
     end
   end
 
-  describe 'display_time' do
-    it 'calls the TimeHelper method' do
+  describe "display_time" do
+    it "calls the TimeHelper method" do
       expect(TimeHelper).to receive(:display_time)
       display_time(120)
     end
   end
 
-  describe 'display_link_to_plan' do
+  describe "display_link_to_plan" do
     let(:current_user) { create(:user) }
 
-    describe 'when the current_user has an upcoming meal_plan' do
-      it 'returns a link to that meal_plan' do
+    describe "when the current_user has an upcoming meal_plan" do
+      it "returns a link to that meal_plan" do
         meal_plan = create(:meal_plan, user: current_user, prepared_on: (Time.zone.today + 5))
         expect(display_link_to_plan).to include("meal_plans/#{meal_plan.id}")
       end
     end
 
-    describe 'when the current_user does not have an upcoming meal_plan' do
-      it 'returns nil' do
+    describe "when the current_user does not have an upcoming meal_plan" do
+      it "returns nil" do
         expect(display_link_to_plan).to be(nil)
       end
     end
   end
 
-  describe 'display_list_and_count' do
+  describe "display_list_and_count" do
     let(:current_user) { create(:user) }
 
-    describe 'when a current_user has no shopping lists' do
-      it 'returns an empty string' do
-        expect(display_list_and_count).to eq('')
+    describe "when a current_user has no shopping lists" do
+      it "returns an empty string" do
+        expect(display_list_and_count).to eq("")
       end
     end
 
-    describe 'when a current_user has a default shopping list' do
+    describe "when a current_user has a default shopping list" do
       let!(:list) {
-        create(:shopping_list, user: current_user, name: 'Foo', main: true)
+        create(:shopping_list, user: current_user, name: "Foo", main: true)
       }
 
-      it 'returns a link to the list' do
+      it "returns a link to the list" do
         link = "<a class=\"nav-link\" href=\"/shopping_lists/#{list.id}\">"
         expect(display_list_and_count).to include(link)
       end
 
-      it 'includes the list name' do
-        expect(display_list_and_count).to include('Foo: 0')
+      it "includes the list name" do
+        expect(display_list_and_count).to include("Foo: 0")
       end
 
-      it 'includes the item count' do
+      it "includes the item count" do
         create(:shopping_list_item, list: list)
         create(:shopping_list_item, list: list)
-        expect(display_list_and_count).to include('Foo: 2')
+        expect(display_list_and_count).to include("Foo: 2")
       end
     end
   end

--- a/spec/helpers/ingredients_helper_spec.rb
+++ b/spec/helpers/ingredients_helper_spec.rb
@@ -1,121 +1,121 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe IngredientsHelper, type: :helper do
-  describe 'ingredient_display' do
+  describe "ingredient_display" do
     it "displays an ingredient's qty unit and name" do
       ingredient = build(:ingredient,
-                         measurement_unit: 'cup',
-                         quantity: 1,
-                         name: 'water')
-      expected_output = '1 cup water'
+        measurement_unit: "cup",
+        quantity: 1,
+        name: "water")
+      expected_output = "1 cup water"
       expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
 
-    it 'pluralizes the unit when it is a standard unit' do
+    it "pluralizes the unit when it is a standard unit" do
       ingredient = build(:ingredient,
-                         measurement_unit: 'cup',
-                         quantity: 2,
-                         name: 'water')
-      expected_output = '2 cups water'
+        measurement_unit: "cup",
+        quantity: 2,
+        name: "water")
+      expected_output = "2 cups water"
       expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
 
-    it 'pluralizes the name when the unit is a descriptive unit' do
+    it "pluralizes the name when the unit is a descriptive unit" do
       ingredient = build(:ingredient,
-                         measurement_unit: 'whole',
-                         quantity: 2,
-                         name: 'carrot')
-      expected_output = '2 whole carrots'
+        measurement_unit: "whole",
+        quantity: 2,
+        name: "carrot")
+      expected_output = "2 whole carrots"
       expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
 
-    it 'if present, displays the preparation_style' do
+    it "if present, displays the preparation_style" do
       ingredient = build(:ingredient,
-                         preparation_style: 'minced',
-                         measurement_unit: 'clove',
-                         quantity: 3,
-                         name: 'garlic')
-      expected_output = '3 cloves garlic: minced'
+        preparation_style: "minced",
+        measurement_unit: "clove",
+        quantity: 3,
+        name: "garlic")
+      expected_output = "3 cloves garlic: minced"
       expect(helper.ingredient_display(ingredient)).to eq(expected_output)
     end
   end
 
-  describe 'detail_display' do
+  describe "detail_display" do
     let(:recipe) { create(:recipe) }
 
     it "displays an ingredient's qty and unit" do
       ingredient = build(
         :ingredient,
         quantity: 1,
-        measurement_unit: 'cup',
+        measurement_unit: "cup",
         recipe: recipe
       )
-      expected_output = '1 cup'
+      expected_output = "1 cup"
       expect(helper.detail_display(ingredient)).to eq(expected_output)
     end
 
-    it 'includes prep style when present' do
+    it "includes prep style when present" do
       ingredient = build(
         :ingredient,
-        name: 'tomato',
+        name: "tomato",
         quantity: 1,
-        measurement_unit: 'cup',
-        preparation_style: 'diced',
+        measurement_unit: "cup",
+        preparation_style: "diced",
         recipe: recipe
       )
-      expected_output = '1 cup diced'
+      expected_output = "1 cup diced"
       expect(helper.detail_display(ingredient)).to eq(expected_output)
     end
 
-    describe 'pluralization' do
-      it 'pluralizes the unit when it is a standard unit' do
+    describe "pluralization" do
+      it "pluralizes the unit when it is a standard unit" do
         ingredient = build(
           :ingredient,
-          measurement_unit: 'cup',
+          measurement_unit: "cup",
           quantity: 2,
           recipe: recipe
         )
-        expected_output = '2 cups'
+        expected_output = "2 cups"
         expect(helper.detail_display(ingredient)).to eq(expected_output)
       end
 
-      it 'does not pluralizes the unit when the unit is a descriptive unit' do
+      it "does not pluralizes the unit when the unit is a descriptive unit" do
         ingredient = build(
           :ingredient,
-          measurement_unit: 'whole',
+          measurement_unit: "whole",
           quantity: 2,
           recipe: recipe
         )
-        expected_output = '2 whole'
+        expected_output = "2 whole"
         expect(helper.detail_display(ingredient)).to eq(expected_output)
       end
     end
   end
 
-  describe 'qty_display' do
-    it 'displays whole numbers as integers' do
+  describe "qty_display" do
+    it "displays whole numbers as integers" do
       ingredient = build(:ingredient, quantity: 1)
       expect(helper.qty_display(ingredient)).to eq(1)
     end
 
-    it 'displays known fractions as fractions' do
+    it "displays known fractions as fractions" do
       ingredient = build(:ingredient, quantity: 0.125)
-      expect(helper.qty_display(ingredient)).to eq('1/8')
+      expect(helper.qty_display(ingredient)).to eq("1/8")
     end
 
-    it 'handles 1/3 gracefully' do
+    it "handles 1/3 gracefully" do
       ingredient = build(:ingredient, quantity: 0.3)
-      expect(helper.qty_display(ingredient)).to eq('1/3')
+      expect(helper.qty_display(ingredient)).to eq("1/3")
     end
 
-    it 'handles 1/6 gracefully' do
+    it "handles 1/6 gracefully" do
       ingredient = build(:ingredient, quantity: 0.6)
-      expect(helper.qty_display(ingredient)).to eq('2/3')
+      expect(helper.qty_display(ingredient)).to eq("2/3")
     end
 
-    it 'rounds other unknown floats to 3 places' do
+    it "rounds other unknown floats to 3 places" do
       ingredient = build(:ingredient, quantity: 0.711765)
       expect(helper.qty_display(ingredient)).to eq(0.712)
     end

--- a/spec/helpers/meal_plans_helper_spec.rb
+++ b/spec/helpers/meal_plans_helper_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe MealPlansHelper, type: :helper do
-  describe 'display_recipes' do
-    it 'displays all recipes titles as links in a concatenated list joined by commas' do
+  describe "display_recipes" do
+    it "displays all recipes titles as links in a concatenated list joined by commas" do
       meal_plan = create(:meal_plan)
-      recipe1 = create(:recipe, title: 'RecipeTitle1')
-      recipe2 = create(:recipe, title: 'RecipeTitle2')
+      recipe1 = create(:recipe, title: "RecipeTitle1")
+      recipe2 = create(:recipe, title: "RecipeTitle2")
       meal_plan.recipes << [recipe1, recipe2]
 
       expect(display_recipes(meal_plan)).to eq("<a href=\"/recipes/#{recipe1.id}\">RecipeTitle1</a>, <a href=\"/recipes/#{recipe2.id}\">RecipeTitle2</a>")

--- a/spec/helpers/numbers_helper_spec.rb
+++ b/spec/helpers/numbers_helper_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe NumbersHelper, type: :helper do
-  describe 'self.whole_number?' do
-    it 'returns true if a float is a whole number' do
+  describe "self.whole_number?" do
+    it "returns true if a float is a whole number" do
       expect(NumbersHelper.whole_number?(1.0)).to eq(true)
     end
 
-    it 'returns false if a float is not a whole number' do
+    it "returns false if a float is not a whole number" do
       expect(NumbersHelper.whole_number?(1.1)).to eq(false)
     end
   end
 
-  describe 'self.prettify_float' do
-    it 'returns a whole number float as an integer' do
+  describe "self.prettify_float" do
+    it "returns a whole number float as an integer" do
       expect(NumbersHelper.prettify_float(1.0)).to eq(1)
     end
 
-    it 'returns a float with a .0 greater than 0 as a float' do
+    it "returns a float with a .0 greater than 0 as a float" do
       expect(NumbersHelper.prettify_float(1.5)).to eq(1.5)
     end
   end

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe RecipesHelper, type: :helper do
-  describe 'guaranteed_image' do
-    let(:recipe) { build(:recipe, image_url: '') }
-    it 'ensures an image file is returned' do
-      expect(helper.guaranteed_image(recipe)).to eq('recipe_placeholder.jpg')
+  describe "guaranteed_image" do
+    let(:recipe) { build(:recipe, image_url: "") }
+    it "ensures an image file is returned" do
+      expect(helper.guaranteed_image(recipe)).to eq("recipe_placeholder.jpg")
     end
   end
 
-  describe 'status_flag' do
+  describe "status_flag" do
     it 'returns "archived" when recipe is not active' do
       recipe = build(:recipe, archived: true)
-      expect(helper.status_flag(recipe)).to include('Archived')
+      expect(helper.status_flag(recipe)).to include("Archived")
     end
 
     it 'returns "new" when recipe has no prep dates' do
       recipe = build(:recipe)
       recipe.meal_plan_recipes = []
 
-      expect(helper.status_flag(recipe)).to include('new_releases')
+      expect(helper.status_flag(recipe)).to include("new_releases")
     end
 
     it 'returns "new" when recipe has no prep dates before today' do
       recipe = build(:recipe)
       recipe.meal_plans << create(:meal_plan, prepared_on: Time.zone.today)
 
-      expect(helper.status_flag(recipe)).to include('new_releases')
+      expect(helper.status_flag(recipe)).to include("new_releases")
     end
 
     it 'returns "been a while" when recipe has not been made in the past 4 months' do
@@ -35,20 +35,20 @@ RSpec.describe RecipesHelper, type: :helper do
       four_months_ago = Time.zone.today - 5.months
       recipe.meal_plans << create(:meal_plan, prepared_on: four_months_ago)
 
-      expect(helper.status_flag(recipe)).to include('calendar_clock')
+      expect(helper.status_flag(recipe)).to include("calendar_clock")
     end
 
-    it 'does not return a flag when recipe was made recently' do
+    it "does not return a flag when recipe was made recently" do
       recipe = create(:recipe)
       four_days_ago = Time.zone.today - 4.days
       recipe.meal_plans << create(:meal_plan, prepared_on: four_days_ago)
 
-      expect(helper.status_flag(recipe)).to eq('')
+      expect(helper.status_flag(recipe)).to eq("")
     end
   end
 
-  describe 'recipe_ingredient_ids' do
-    it 'returns an array of ingredient ids from this recipe' do
+  describe "recipe_ingredient_ids" do
+    it "returns an array of ingredient ids from this recipe" do
       recipe = create(:recipe, :with_2_ingredients)
 
       expect(helper.recipe_ingredient_ids(recipe)).to be_a(Array)

--- a/spec/helpers/scheduled_deliveries_helper_spec.rb
+++ b/spec/helpers/scheduled_deliveries_helper_spec.rb
@@ -1,31 +1,31 @@
 # frozen_string_literal: true
 
 RSpec.describe ScheduledDeliveriesHelper, type: :helper do
-  describe 'display_scheduled_deliveries' do
-    it 'displays the day of the week, date, and time' do
-      delivery_date = '2020-05-12 10:00:00 UTC' # 6am US Eastern
+  describe "display_scheduled_deliveries" do
+    it "displays the day of the week, date, and time" do
+      delivery_date = "2020-05-12 10:00:00 UTC" # 6am US Eastern
       delivery1 = create(:scheduled_delivery, scheduled_for: delivery_date)
       deliveries = [delivery1]
 
       expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery1.service_provider)
-      expect(helper.display_scheduled_deliveries(deliveries)).to include('Tue 05/12 at 6:00 am')
+      expect(helper.display_scheduled_deliveries(deliveries)).to include("Tue 05/12 at 6:00 am")
     end
 
-    it 'joins multiple deliveries with a pipe' do
+    it "joins multiple deliveries with a pipe" do
       delivery1 = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
       delivery2 = create(:scheduled_delivery, scheduled_for: 4.days.from_now)
       deliveries = ScheduledDelivery.all
 
       expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery1.service_provider)
       expect(helper.display_scheduled_deliveries(deliveries)).to include(delivery2.service_provider)
-      expect(helper.display_scheduled_deliveries(deliveries)).to include(' | ')
+      expect(helper.display_scheduled_deliveries(deliveries)).to include(" | ")
     end
 
-    it 'display time in 12-hour format' do
-      delivery_date = '2020-05-12 18:00:00 UTC' # 2pm US Eastern
+    it "display time in 12-hour format" do
+      delivery_date = "2020-05-12 18:00:00 UTC" # 2pm US Eastern
       delivery = create(:scheduled_delivery, scheduled_for: delivery_date)
 
-      expect(helper.display_scheduled_deliveries([delivery])).to include('Tue 05/12 at 2:00 pm')
+      expect(helper.display_scheduled_deliveries([delivery])).to include("Tue 05/12 at 2:00 pm")
     end
   end
 end

--- a/spec/helpers/shopping_lists_helper_spec.rb
+++ b/spec/helpers/shopping_lists_helper_spec.rb
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ShoppingListsHelper, type: :helper do
-  describe 'toggle_favorite' do
-    it 'when a list is favorited, it links to unfavorite' do
+  describe "toggle_favorite" do
+    it "when a list is favorited, it links to unfavorite" do
       list = create(:shopping_list, favorite: true)
       output = toggle_favorite(list)
-      http_destroy_verb = 'delete'
+      http_destroy_verb = "delete"
 
       expect(output).to include(http_destroy_verb)
     end
 
-    it 'when a list is not favorited, it links to favorite' do
+    it "when a list is not favorited, it links to favorite" do
       list = create(:shopping_list, favorite: false)
       output = toggle_favorite(list)
-      http_create_verb = 'post'
+      http_create_verb = "post"
 
       expect(output).to include(http_create_verb)
     end
   end
 
-  describe 'display_quantity' do
-    it 'displays the integerized number in parentheses if the value is greater than 1' do
+  describe "display_quantity" do
+    it "displays the integerized number in parentheses if the value is greater than 1" do
       shopping_list_item = build(:shopping_list_item, quantity: 2.0)
-      expect(display_quantity(shopping_list_item)).to eq('(2)')
+      expect(display_quantity(shopping_list_item)).to eq("(2)")
     end
 
-    it 'displays nothing if the value is 1' do
+    it "displays nothing if the value is 1" do
       shopping_list_item = build(:shopping_list_item, quantity: 1)
       expect(display_quantity(shopping_list_item)).to eq(nil)
     end
 
-    it 'displays nothing if the value is == 1' do
+    it "displays nothing if the value is == 1" do
       shopping_list_item = build(:shopping_list_item, quantity: 1)
       expect(display_quantity(shopping_list_item)).to eq(nil)
     end

--- a/spec/helpers/time_helper_spec.rb
+++ b/spec/helpers/time_helper_spec.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe TimeHelper, type: :helper do
-  describe 'self.display_time' do
-    it 'displays time as minutes if less than 60' do
+  describe "self.display_time" do
+    it "displays time as minutes if less than 60" do
       displayed_time = TimeHelper.display_time(55)
-      expect(displayed_time).to eq('55m')
+      expect(displayed_time).to eq("55m")
     end
 
-    it 'displays time as min if 60 min' do
+    it "displays time as min if 60 min" do
       displayed_time = TimeHelper.display_time(60)
-      expect(displayed_time).to eq('60m')
+      expect(displayed_time).to eq("60m")
     end
 
-    it 'displays time as hour/min if 60 min or more' do
+    it "displays time as hour/min if 60 min or more" do
       displayed_time = TimeHelper.display_time(120)
-      expect(displayed_time).to eq('2h 0m')
+      expect(displayed_time).to eq("2h 0m")
     end
   end
 end

--- a/spec/models/aisle_spec.rb
+++ b/spec/models/aisle_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe Aisle, type: :model do
   let(:aisle) { build(:aisle) }
 
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:user) }
     it { should have_many(:shopping_list_items) }
   end
 
-  describe 'a valid aisle' do
-    context 'when has valid params' do
-      it 'is valid' do
+  describe "a valid aisle" do
+    context "when has valid params" do
+      it "is valid" do
         expect(aisle).to be_valid
       end
 
@@ -20,12 +20,12 @@ RSpec.describe Aisle, type: :model do
     end
   end
 
-  describe 'self.unassigned' do
+  describe "self.unassigned" do
     let(:user) { create(:user) }
     let(:shopping_list) { create(:shopping_list, user: user) }
 
     it 'returns the existing aisle called "Unassigned" that belongs to the current_user' do
-      existing_aisle = create(:aisle, user: user, name: 'Unassigned')
+      existing_aisle = create(:aisle, user: user, name: "Unassigned")
       retured_aisle = Aisle.unassigned(shopping_list)
 
       expect(retured_aisle).to eq(existing_aisle)
@@ -34,12 +34,12 @@ RSpec.describe Aisle, type: :model do
     it 'creates a new aisle called "Unassigned" for the user if one does not exist' do
       retured_aisle = Aisle.unassigned(shopping_list)
 
-      expect(retured_aisle.name).to eq('unassigned')
+      expect(retured_aisle.name).to eq("unassigned")
     end
   end
 
-  describe 'self.by_order_number' do
-    it 'orders by order_number, ascending' do
+  describe "self.by_order_number" do
+    it "orders by order_number, ascending" do
       second_aisle = create(:aisle, order_number: 2)
       first_aisle = create(:aisle, order_number: 1)
 

--- a/spec/models/experimental_recipe_spec.rb
+++ b/spec/models/experimental_recipe_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ExperimentalRecipe, type: :model do
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:user) }
   end
 
-  describe 'a valid recipe' do
+  describe "a valid recipe" do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:source_url) }
   end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -3,13 +3,13 @@
 RSpec.describe Ingredient, type: :model do
   let(:ingredient) { build(:ingredient) }
 
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:recipe) }
   end
 
-  describe 'a valid ingredient' do
-    context 'when has valid params' do
-      it 'is valid' do
+  describe "a valid ingredient" do
+    context "when has valid params" do
+      it "is valid" do
         expect(ingredient).to be_valid
       end
 
@@ -19,37 +19,37 @@ RSpec.describe Ingredient, type: :model do
       it { should validate_inclusion_of(:measurement_unit).in_array(Ingredient::UNITS) }
     end
 
-    context 'quantity' do
-      it 'is valid with a float' do
-        ingredient.quantity = '0.0222'
+    context "quantity" do
+      it "is valid with a float" do
+        ingredient.quantity = "0.0222"
         expect(ingredient.valid?).to be true
       end
 
-      it 'is valid with an integer' do
-        ingredient.quantity = '2'
+      it "is valid with an integer" do
+        ingredient.quantity = "2"
         expect(ingredient.valid?).to be true
       end
 
-      it 'is valid with a space' do
-        ingredient.quantity = '    0.2222   '
+      it "is valid with a space" do
+        ingredient.quantity = "    0.2222   "
         expect(ingredient.valid?).to be true
       end
 
-      it 'is invalid with a non-number' do
-        ingredient.quantity = 'tacos'
+      it "is invalid with a non-number" do
+        ingredient.quantity = "tacos"
         expect(ingredient.valid?).to be false
       end
     end
 
-    context 'a valid preparation_style' do
-      let(:invalid_style) { 'invalid style' }
+    context "a valid preparation_style" do
+      let(:invalid_style) { "invalid style" }
 
-      it 'may be blank' do
+      it "may be blank" do
         ingredient.preparation_style = nil
         expect(ingredient).to be_valid
       end
 
-      xit 'must be one from the list of styles' do
+      xit "must be one from the list of styles" do
         ingredient.preparation_style = Ingredient::STYLES.sample
         expect(ingredient).to be_valid
 

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Inventory, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe MealPlanRecipe, type: :model do
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:meal_plan) }
     it { should belong_to(:recipe) }
   end
 
-  context 'validations' do
-    it 'is valid' do
+  context "validations" do
+    it "is valid" do
       expect(meal_plan_recipe).to be_valid
     end
 

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe MealPlan, type: :model do
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:user) }
     it { should have_many(:meal_plan_recipes) }
     it { should have_many(:recipes).through(:meal_plan_recipes) }
     it { should have_many(:ingredients).through(:recipes) }
   end
 
-  describe 'a valid meal_plan' do
+  describe "a valid meal_plan" do
     let(:meal_plan) { build(:meal_plan) }
 
-    context 'when has valid params' do
-      it 'is valid' do
+    context "when has valid params" do
+      it "is valid" do
         expect(meal_plan).to be_valid
       end
     end
@@ -20,14 +20,14 @@ RSpec.describe MealPlan, type: :model do
     it { should validate_presence_of(:prepared_on) }
     it { should validate_presence_of(:people_served) }
 
-    it 'has a unique prepared_on scoped to user' do
+    it "has a unique prepared_on scoped to user" do
       create(:meal_plan)
       should validate_uniqueness_of(:prepared_on).scoped_to(:user_id)
     end
   end
 
-  describe 'self.most_recent_first' do
-    it 'displays all meal plans in descending prepared_on order' do
+  describe "self.most_recent_first" do
+    it "displays all meal plans in descending prepared_on order" do
       meal_plan1 = create(:meal_plan, prepared_on: Time.zone.yesterday)
       meal_plan2 = create(:meal_plan, prepared_on: Time.zone.today)
 
@@ -36,24 +36,24 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe 'self.suggested_date' do
+  describe "self.suggested_date" do
     let(:user) { create(:user) }
-    let(:random_wednesday) { '2020-08-05'.to_date }
+    let(:random_wednesday) { "2020-08-05".to_date }
 
-    it 'returns upcoming sunday if there are no meal plans for the user' do
-      today_saturday = '2020-08-01'.to_date
-      upcoming_sunday = '2020-08-02'.to_date
+    it "returns upcoming sunday if there are no meal plans for the user" do
+      today_saturday = "2020-08-01".to_date
+      upcoming_sunday = "2020-08-02".to_date
       allow(Date).to receive(:today).and_return(today_saturday)
 
       date = MealPlan.suggested_date(user)
       expect(date).to eq(upcoming_sunday)
     end
 
-    it 'returns upcoming sunday if the latest meal plan is more than a week old' do
-      today_saturday = '2020-08-01'.to_date
-      seven_days_ago = '2020-07-26'.to_date
-      upcoming_sunday = '2020-08-02'.to_date
-      latest_plan_date = '2020-07-25'.to_date
+    it "returns upcoming sunday if the latest meal plan is more than a week old" do
+      "2020-08-01".to_date
+      "2020-07-26".to_date
+      upcoming_sunday = "2020-08-02".to_date
+      latest_plan_date = "2020-07-25".to_date
       create(:meal_plan, user: user, prepared_on: latest_plan_date)
 
       # Travel to today_saturday
@@ -63,11 +63,11 @@ RSpec.describe MealPlan, type: :model do
       end
     end
 
-    it 'returns date_after_last_meal_plan if the latest meal_plan is only a week old' do
-      today_saturday = '2020-08-01'.to_date
-      seven_days_ago = '2020-07-26'.to_date
-      upcoming_sunday = '2020-08-02'.to_date
-      latest_plan_date = '2020-07-28'.to_date
+    it "returns date_after_last_meal_plan if the latest meal_plan is only a week old" do
+      "2020-08-01".to_date
+      "2020-07-26".to_date
+      "2020-08-02".to_date
+      latest_plan_date = "2020-07-28".to_date
       create(:meal_plan, user: user, prepared_on: latest_plan_date)
 
       # Travel to today_saturday
@@ -78,18 +78,18 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe 'self.date_after_last_meal_plan' do
+  describe "self.date_after_last_meal_plan" do
     let(:user) { create(:user) }
-    let(:random_wednesday) { '2020-08-05'.to_date }
+    let(:random_wednesday) { "2020-08-05".to_date }
 
-    it 'chooses a date later than the latest meal plan' do
+    it "chooses a date later than the latest meal plan" do
       plan1 = create(:meal_plan, user: user, prepared_on: random_wednesday)
       new_date = MealPlan.date_after_last_meal_plan(random_wednesday)
 
       expect(new_date).to be > plan1.prepared_on
     end
 
-    it 'chooses a sunday' do
+    it "chooses a sunday" do
       create(:meal_plan, user: user, prepared_on: random_wednesday)
       new_date = MealPlan.date_after_last_meal_plan(random_wednesday)
       sunday_number = 0
@@ -98,8 +98,8 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe 'self.future' do
-    it 'returns a list of meal plans starting today or in the future' do
+  describe "self.future" do
+    it "returns a list of meal plans starting today or in the future" do
       user = build(:user)
       past_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today - 2)
       todays_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today)
@@ -114,8 +114,8 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe 'upcoming' do
-    it 'returns a single meal plan' do
+  describe "upcoming" do
+    it "returns a single meal plan" do
       user = build(:user)
       past_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today - 2)
       upcoming_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 2)
@@ -127,7 +127,7 @@ RSpec.describe MealPlan, type: :model do
       expect(user_upcoming_plan).to_not eq(future_plan)
     end
 
-    it 'returns the meal plan that is next closest in the future to today' do
+    it "returns the meal plan that is next closest in the future to today" do
       user = build(:user)
       upcoming_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 2)
       future_plan = create(:meal_plan, user: user, prepared_on: Time.zone.today + 4)
@@ -138,12 +138,12 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe '#total_servings' do
+  describe "#total_servings" do
     let(:meal_plan) { build(:meal_plan) }
     let(:standard_servings) { 2 }
     let(:qty_recipes) { 2 }
 
-    it 'returns a total of servings for all recipes in meal plan' do
+    it "returns a total of servings for all recipes in meal plan" do
       qty_recipes.times do
         meal_plan.recipes << create(:recipe, servings: standard_servings)
         meal_plan.save
@@ -152,17 +152,17 @@ RSpec.describe MealPlan, type: :model do
       expect(meal_plan.total_servings).to eq(standard_servings * qty_recipes)
     end
 
-    it 'returns zero if there are no recipes' do
+    it "returns zero if there are no recipes" do
       expect(meal_plan.total_servings).to eq(0)
     end
   end
 
-  describe '#total_prep_time' do
+  describe "#total_prep_time" do
     let(:meal_plan) { build(:meal_plan) }
     let(:standard_prep_time) { 2 }
     let(:qty_recipes) { 2 }
 
-    it 'returns a prep time total for all recipes in meal plan' do
+    it "returns a prep time total for all recipes in meal plan" do
       qty_recipes.times do
         meal_plan.recipes << create(:recipe, prep_time: standard_prep_time)
         meal_plan.save
@@ -170,17 +170,17 @@ RSpec.describe MealPlan, type: :model do
       expect(meal_plan.total_prep_time).to eq(standard_prep_time * qty_recipes)
     end
 
-    it 'returns zero if there are no recipes' do
+    it "returns zero if there are no recipes" do
       expect(meal_plan.total_prep_time).to eq(0)
     end
   end
 
-  describe '#total_cook_time' do
+  describe "#total_cook_time" do
     let(:meal_plan) { build(:meal_plan) }
     let(:standard_cook_time) { 2 }
     let(:qty_recipes) { 2 }
 
-    it 'returns a cook time total for all recipes in meal plan' do
+    it "returns a cook time total for all recipes in meal plan" do
       qty_recipes.times do
         meal_plan.recipes << create(:recipe, cook_time: standard_cook_time)
         meal_plan.save
@@ -189,19 +189,19 @@ RSpec.describe MealPlan, type: :model do
       expect(meal_plan.total_cook_time).to eq(standard_cook_time * qty_recipes)
     end
 
-    it 'returns zero if there are no recipes' do
+    it "returns zero if there are no recipes" do
       expect(meal_plan.total_cook_time).to eq(0)
     end
   end
 
-  describe '#total_time' do
+  describe "#total_time" do
     let(:meal_plan) { build(:meal_plan) }
     let(:standard_cook_time) { 2 }
     let(:standard_prep_time) { 2 }
     let(:qty_recipes) { 2 }
     let(:total_standard_time) { (standard_cook_time + standard_prep_time) * qty_recipes }
 
-    it 'returns a time total for all recipes in meal plan' do
+    it "returns a time total for all recipes in meal plan" do
       qty_recipes.times do
         meal_plan.recipes << create(:recipe, prep_time: standard_prep_time, cook_time: standard_cook_time)
         meal_plan.save
@@ -211,10 +211,10 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe '#estimated_time' do
+  describe "#estimated_time" do
     let(:meal_plan) { create(:meal_plan) }
 
-    it 'will output a time shorter than the total cook time' do
+    it "will output a time shorter than the total cook time" do
       minutes = 100
       rate = 0.5
       est_time = 50
@@ -226,30 +226,30 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
-  describe '#recommended_start_time' do
+  describe "#recommended_start_time" do
     let(:meal_plan) { create(:meal_plan) }
 
-    it 'outputs in time format' do
-      time = Time.zone.parse('12:00 PM')
+    it "outputs in time format" do
+      time = Time.zone.parse("12:00 PM")
       est_minutes = 60
-      expected_time = Time.zone.parse('11:00 AM').strftime('%I:%M %p')
+      expected_time = Time.zone.parse("11:00 AM").strftime("%I:%M %p")
       allow(meal_plan).to receive(:prep_end_time).and_return(time)
       allow(meal_plan).to receive(:estimated_time).and_return(est_minutes)
 
       expect(meal_plan.recommended_start_time).to eq(expected_time)
     end
 
-    xit 'will never be later than MealPlan::PREP_END_TIME'
+    xit "will never be later than MealPlan::PREP_END_TIME"
   end
 
-  describe '#meals' do
+  describe "#meals" do
     let(:meal_plan) { build(:meal_plan) }
     let(:standard_servings) { 2 }
     let(:qty_recipes) { 2 }
     let(:total_servings) { standard_servings * qty_recipes }
     let(:expected_qty) { total_servings / meal_plan.people_served }
 
-    it 'returns the number of servings for recipes divided by people served in a meal plan' do
+    it "returns the number of servings for recipes divided by people served in a meal plan" do
       qty_recipes.times do
         meal_plan.recipes << create(:recipe, servings: standard_servings)
         meal_plan.save
@@ -257,12 +257,12 @@ RSpec.describe MealPlan, type: :model do
       expect(meal_plan.meals).to eq(expected_qty)
     end
 
-    it 'returns zero if there are no recipes' do
+    it "returns zero if there are no recipes" do
       expect(meal_plan.meals).to eq(0)
     end
   end
 
-  describe '#total_unique_ingredients' do
+  describe "#total_unique_ingredients" do
     let(:meal_plan) { build(:meal_plan) }
     let(:qty_recipes) { 2 }
     let(:recipe1) { create(:recipe) }
@@ -270,7 +270,7 @@ RSpec.describe MealPlan, type: :model do
     let(:ingredient1) { build(:ingredient) }
     let(:ingredient2) { build(:ingredient) }
 
-    it 'returns a count of all unique ingredients used in meal plan' do
+    it "returns a count of all unique ingredients used in meal plan" do
       recipe1.ingredients << ingredient1
       recipe1.save
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Recipe, type: :model do
   let(:recipe) { build(:recipe) }
 
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:user) }
     it { should have_many(:ingredients) }
     it { should have_many(:meal_plan_recipes) }
@@ -12,9 +12,9 @@ RSpec.describe Recipe, type: :model do
     it { should accept_nested_attributes_for(:ingredients).allow_destroy(true) }
   end
 
-  describe 'a valid recipe' do
-    context 'when has valid params' do
-      it 'is valid' do
+  describe "a valid recipe" do
+    context "when has valid params" do
+      it "is valid" do
         expect(recipe).to be_valid
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Recipe, type: :model do
     it { should validate_presence_of(:cook_time) }
     it { should validate_presence_of(:reheat_time) }
 
-    it 'ensures that 1 of [prep_time | cook_time | reheat_time] has a value' do
+    it "ensures that 1 of [prep_time | cook_time | reheat_time] has a value" do
       recipe = build(:recipe, prep_time: 0, cook_time: 0, reheat_time: 0)
       expect(recipe).to_not be_valid
 
@@ -38,88 +38,88 @@ RSpec.describe Recipe, type: :model do
       expect(recipe).to be_valid
     end
 
-    describe 'title uniqueness' do
+    describe "title uniqueness" do
       let(:user_1) { create(:user) }
       let(:user_2) { create(:user) }
 
       it 'considers "FOO" and "foo" to be the same title' do
-        recipe_1 = create(:recipe, user_id: user_1.id, title: "FOO")
+        create(:recipe, user_id: user_1.id, title: "FOO")
         recipe_2 = build(:recipe, user_id: user_1.id, title: "foo")
         expect(recipe_2.valid?).to be(false)
       end
 
-      it 'does not permit the same user to have multiple recipes with the same title' do
-        recipe_1 = create(:recipe, user_id: user_1.id, title: "Foo")
+      it "does not permit the same user to have multiple recipes with the same title" do
+        create(:recipe, user_id: user_1.id, title: "Foo")
         recipe_2 = build(:recipe, user_id: user_1.id, title: "Foo")
         expect(recipe_2.valid?).to be(false)
       end
 
-      it 'permits multiple users to have the same recipe title' do
-        recipe_1 = create(:recipe, user_id: user_1.id, title: "Foo")
+      it "permits multiple users to have the same recipe title" do
+        create(:recipe, user_id: user_1.id, title: "Foo")
         recipe_2 = build(:recipe, user_id: user_2.id, title: "Foo")
         expect(recipe_2.valid?).to be(true)
       end
     end
 
-    describe 'before validations' do
-      describe 'guarantee_instructions_values' do
+    describe "before validations" do
+      describe "guarantee_instructions_values" do
         let(:instructions_value) { "instructions value" }
         let(:prep_day_instructions_value) { "prep_day_instructions value" }
 
-        context 'when a new recipe has neither instructions nor prep_day_instructions' do
+        context "when a new recipe has neither instructions nor prep_day_instructions" do
           let(:recipe) { build(:recipe, instructions: "", prep_day_instructions: "") }
 
-          it 'fails validation' do
+          it "fails validation" do
             expect(recipe.valid?).to be(false)
           end
 
-          it 'raises an error on save!' do
-            expect{recipe.save!}.to raise_error(ActiveRecord::RecordInvalid)
+          it "raises an error on save!" do
+            expect { recipe.save! }.to raise_error(ActiveRecord::RecordInvalid)
           end
         end
 
-        context 'when a new recipe has both instructions and prep_day_instructions' do
+        context "when a new recipe has both instructions and prep_day_instructions" do
           let(:recipe) { build(:recipe, instructions: instructions_value, prep_day_instructions: prep_day_instructions_value) }
 
-          it 'does not modify the value for instructions' do
+          it "does not modify the value for instructions" do
             recipe.save
             recipe.reload
             expect(recipe.instructions).to eq(instructions_value)
           end
 
-          it 'does not modify the value for prep_day_instructions' do
+          it "does not modify the value for prep_day_instructions" do
             recipe.save
             recipe.reload
             expect(recipe.prep_day_instructions).to eq(prep_day_instructions_value)
           end
         end
 
-        context 'when a new recipe has instructions but not prep_day_instructions' do
-          let(:recipe) { build(:recipe, instructions: instructions_value, prep_day_instructions: '') }
+        context "when a new recipe has instructions but not prep_day_instructions" do
+          let(:recipe) { build(:recipe, instructions: instructions_value, prep_day_instructions: "") }
 
-          it 'fills the prep_day_instructions field with the instructions data' do
+          it "fills the prep_day_instructions field with the instructions data" do
             recipe.save
             recipe.reload
             expect(recipe.prep_day_instructions).to eq(instructions_value)
           end
 
-          it 'does not modify the value for instructions' do
+          it "does not modify the value for instructions" do
             recipe.save
             recipe.reload
             expect(recipe.instructions).to eq(instructions_value)
           end
         end
 
-        context 'when a new recipe has prep_day_instructions but not instructions' do
-          let(:recipe) { build(:recipe, instructions: '', prep_day_instructions: prep_day_instructions_value) }
+        context "when a new recipe has prep_day_instructions but not instructions" do
+          let(:recipe) { build(:recipe, instructions: "", prep_day_instructions: prep_day_instructions_value) }
 
-          it 'fills the instructions field with the prep_day_instructions data' do
+          it "fills the instructions field with the prep_day_instructions data" do
             recipe.save
             recipe.reload
             expect(recipe.instructions).to eq(prep_day_instructions_value)
           end
 
-          it 'does not modify the value for prep_day_instructions' do
+          it "does not modify the value for prep_day_instructions" do
             recipe.save
             recipe.reload
             expect(recipe.prep_day_instructions).to eq(prep_day_instructions_value)
@@ -127,15 +127,15 @@ RSpec.describe Recipe, type: :model do
         end
       end
 
-      describe 'provide_default_source' do
-        context 'when it does not have a source' do
-          let(:recipe_missing_source) { create(:recipe, source_name: '', source_url: '') }
+      describe "provide_default_source" do
+        context "when it does not have a source" do
+          let(:recipe_missing_source) { create(:recipe, source_name: "", source_url: "") }
 
-          it 'is provided a source name' do
+          it "is provided a source name" do
             expect(recipe_missing_source.source_name).to eq(Recipe::DEFAULT_SOURCE[:source_name])
           end
 
-          it 'is provided a source url' do
+          it "is provided a source url" do
             expect(recipe_missing_source.source_url).to eq(Recipe::DEFAULT_SOURCE[:source_url])
           end
         end
@@ -143,12 +143,12 @@ RSpec.describe Recipe, type: :model do
     end
   end
 
-  describe 'self.by_last_prepared' do
-    it 'puts recipes that have not been made in a while on top' do
+  describe "self.by_last_prepared" do
+    it "puts recipes that have not been made in a while on top" do
       recent_recipe = create(:recipe)
-      create(:meal_plan, recipes: [recent_recipe], prepared_on: '2020-06-15')
+      create(:meal_plan, recipes: [recent_recipe], prepared_on: "2020-06-15")
       old_recipe = create(:recipe)
-      create(:meal_plan, recipes: [old_recipe], prepared_on: '2018-06-15')
+      create(:meal_plan, recipes: [old_recipe], prepared_on: "2018-06-15")
       ordered_recipes = Recipe.includes(:meal_plans, :meal_plan_recipes).by_last_prepared
 
       expect(ordered_recipes.first).to eq(old_recipe)
@@ -156,12 +156,12 @@ RSpec.describe Recipe, type: :model do
     end
   end
 
-  describe '#last_prepared' do
+  describe "#last_prepared" do
     let(:meal_plan_today) { create(:meal_plan, prepared_on: Time.zone.today) }
     let(:meal_plan_yesterday) { create(:meal_plan, prepared_on: Time.zone.yesterday) }
     let(:recipe) { create(:recipe) }
 
-    it 'returns the prepared_on of the most recent meal plan this recipe was included in' do
+    it "returns the prepared_on of the most recent meal plan this recipe was included in" do
       meal_plan_today.recipes << recipe
       meal_plan_yesterday.recipes << recipe
 
@@ -169,37 +169,37 @@ RSpec.describe Recipe, type: :model do
     end
   end
 
-  describe '#total_time' do
-    it 'adds the prep and cook times together' do
+  describe "#total_time" do
+    it "adds the prep and cook times together" do
       recipe.prep_time = 1
       recipe.cook_time = 1
       expect(recipe.total_time).to eq(2)
     end
   end
 
-  describe 'extra_work_required?' do
-    it 'returns true if there is an extra_work_note' do
-      recipe = build(:recipe, extra_work_note: 'lorem')
+  describe "extra_work_required?" do
+    it "returns true if there is an extra_work_note" do
+      recipe = build(:recipe, extra_work_note: "lorem")
       expect(recipe.extra_work_required?).to be(true)
     end
 
-    it 'returns false if the value is nil' do
+    it "returns false if the value is nil" do
       recipe = build(:recipe, extra_work_note: nil)
       expect(recipe.extra_work_required?).to be(false)
     end
 
-    it 'returns false if the value is a blank space' do
-      recipe = build(:recipe, extra_work_note: ' ')
+    it "returns false if the value is a blank space" do
+      recipe = build(:recipe, extra_work_note: " ")
       expect(recipe.extra_work_required?).to be(false)
     end
   end
 
-  describe 'dupe_for_user' do
+  describe "dupe_for_user" do
     let!(:original_recipe_holder) { create(:user) }
     let!(:original_recipe) { create(:recipe, :with_2_ingredients, user_id: original_recipe_holder.id) }
     let!(:recipe_recipient) { create(:user) }
 
-    it 'copies a recipe from one user to another' do
+    it "copies a recipe from one user to another" do
       original_recipe.dupe_for_user(recipe_recipient)
       duped_recipe = recipe_recipient.recipes.first
 
@@ -207,19 +207,19 @@ RSpec.describe Recipe, type: :model do
       expect(recipe_recipient.recipes.first.title).to eq(original_recipe.title)
     end
 
-    it 'brings the recipe ingredients along with the dupe' do
+    it "brings the recipe ingredients along with the dupe" do
       original_recipe.dupe_for_user(recipe_recipient)
       duped_recipe = recipe_recipient.recipes.first
 
       expect(duped_recipe.ingredients.first.name).to eq(original_recipe.ingredients.first.name)
     end
 
-    it 'leaves the original recipe in the original users account' do
+    it "leaves the original recipe in the original users account" do
       original_recipe.dupe_for_user(recipe_recipient)
       expect(original_recipe_holder.recipes.first.title).to eq(original_recipe.title)
     end
 
-    it 'leaves the original recipe ingredients on the original recipe' do
+    it "leaves the original recipe ingredients on the original recipe" do
       ingredient_before = original_recipe_holder.recipes.first.ingredients.first
       original_recipe.dupe_for_user(recipe_recipient)
       ingredient_after = original_recipe_holder.recipes.first.ingredients.first

--- a/spec/models/scheduled_delivery_spec.rb
+++ b/spec/models/scheduled_delivery_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe ScheduledDelivery, type: :model do
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:shopping_list) }
   end
 
-  context 'validations' do
+  context "validations" do
     it { should validate_presence_of(:service_provider) }
     it { should validate_presence_of(:scheduled_for) }
   end
 
-  describe 'self.future' do
-    it 'only displays upcoming deliveries' do
+  describe "self.future" do
+    it "only displays upcoming deliveries" do
       future_delivery = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
       past_delivery = create(:scheduled_delivery, scheduled_for: 3.days.ago)
       results = ScheduledDelivery.future
@@ -20,7 +20,7 @@ RSpec.describe ScheduledDelivery, type: :model do
       expect(results).to_not include(past_delivery)
     end
 
-    it 'displays deliveries in ascending order' do
+    it "displays deliveries in ascending order" do
       second_delivery = create(:scheduled_delivery, scheduled_for: 3.days.from_now)
       first_delivery = create(:scheduled_delivery, scheduled_for: 2.days.from_now)
       results = ScheduledDelivery.future

--- a/spec/models/shopping_list_item_builder_spec.rb
+++ b/spec/models/shopping_list_item_builder_spec.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe ShoppingListItemBuilder, type: :model do
-  describe 'self.add_item_to_list' do
-    context 'when the item is not on the list' do
+  describe "self.add_item_to_list" do
+    context "when the item is not on the list" do
       let(:shopping_list) { create(:shopping_list, main: true) }
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list) }
 
       before do
         ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-                                                 incoming_item: incoming_item)
+          incoming_item: incoming_item)
       end
 
-      it 'creates a new the item' do
+      it "creates a new the item" do
         expect(shopping_list.items.count).to eq(1)
       end
 
-      it 'sets the item to active' do
+      it "sets the item to active" do
         item = shopping_list.items.first
         expect(item.active?).to be true
       end
 
-      it 'sets the quantity to the incoming quantity' do
+      it "sets the quantity to the incoming quantity" do
         incoming_quantity = incoming_item.quantity
         item = shopping_list.items.first
 
@@ -28,66 +28,66 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       end
     end
 
-    context 'when the item is already active on the list' do
-      let(:shopping_list_item) { create(:shopping_list_item, status: 'active', quantity: 2) }
+    context "when the item is already active on the list" do
+      let(:shopping_list_item) { create(:shopping_list_item, status: "active", quantity: 2) }
       let(:shopping_list) { shopping_list_item.shopping_list }
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 2, name: shopping_list_item.name) }
 
       before do
         ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-                                                 incoming_item: incoming_item)
+          incoming_item: incoming_item)
       end
 
-      it 'adds the incoming quantity to the existing quantity' do
+      it "adds the incoming quantity to the existing quantity" do
         item = shopping_list.items.first
         expect(item.quantity).to eq(4)
       end
     end
 
-    context 'when the item is already inactive on the list' do
-      let(:shopping_list_item) { create(:shopping_list_item, status: 'inactive', quantity: 5) }
+    context "when the item is already inactive on the list" do
+      let(:shopping_list_item) { create(:shopping_list_item, status: "inactive", quantity: 5) }
       let(:shopping_list) { shopping_list_item.shopping_list }
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 1, name: shopping_list_item.name) }
 
       before do
         ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-                                                 incoming_item: incoming_item)
+          incoming_item: incoming_item)
       end
 
-      it 'sets the item quantity to the incoming quantity' do
+      it "sets the item quantity to the incoming quantity" do
         item = shopping_list.items.first
         expect(item.quantity).to eq(incoming_item.quantity)
       end
 
-      it 'sets the item to active' do
+      it "sets the item to active" do
         item = shopping_list.items.first
         expect(item.active?).to be(true)
       end
     end
 
-    context 'when the item is already in_cart on the list' do
-      let(:shopping_list_item) { create(:shopping_list_item, status: 'in_cart', quantity: 5) }
+    context "when the item is already in_cart on the list" do
+      let(:shopping_list_item) { create(:shopping_list_item, status: "in_cart", quantity: 5) }
       let(:shopping_list) { shopping_list_item.shopping_list }
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 1, name: shopping_list_item.name) }
 
       before do
         ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-                                                 incoming_item: incoming_item)
+          incoming_item: incoming_item)
       end
 
-      it 'adds the incoming quantity to the existing quantity' do
+      it "adds the incoming quantity to the existing quantity" do
         item = shopping_list.items.first
         expect(item.quantity).to eq(6)
       end
 
-      it 'does not modify the status' do
+      it "does not modify the status" do
         item = shopping_list.items.first
-        expect(item.status).to eq('in_cart')
+        expect(item.status).to eq("in_cart")
       end
     end
   end
 
-  describe '#add_ingredients_to_list' do
+  describe "#add_ingredients_to_list" do
     let(:shopping_list) { create(:shopping_list, main: true) }
     # let(:meal_plan) { create(:meal_plan) }
     # let(:recipe) { create(:recipe) }
@@ -95,10 +95,10 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
     let(:ingredients) { create_list(:ingredient, 3) }
     # let(:ingredient_ids) { ingredient.id }
     let(:ingredient_ids) { ingredients.pluck(:id) }
-    let!(:aisle) { create(:aisle, name: 'Unassigned') }
+    let!(:aisle) { create(:aisle, name: "Unassigned") }
 
-    context 'when passed an array' do
-      it 'adds all ingredients as shopping_list_items on the given shopping_list' do
+    context "when passed an array" do
+      it "adds all ingredients as shopping_list_items on the given shopping_list" do
         described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: ingredient_ids)
         expected_list_items = ingredients.map(&:measurement_and_name)
         actual_list_items = shopping_list.shopping_list_items.map(&:name)
@@ -107,8 +107,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       end
     end
 
-    context 'when passed a single ingredient' do
-      it 'adds all ingredients as shopping_list_items on the given shopping_list' do
+    context "when passed a single ingredient" do
+      it "adds all ingredients as shopping_list_items on the given shopping_list" do
         ingredient_ids = [ingredients.first.id]
         described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: ingredient_ids)
 
@@ -119,8 +119,8 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       end
     end
 
-    context 'when an ingredient is new to the shopping list' do
-      it 'the list item quantity equals the ingredient quantity' do
+    context "when an ingredient is new to the shopping list" do
+      it "the list item quantity equals the ingredient quantity" do
         ingredient_ids = [ingredients.first.id]
         described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: ingredient_ids)
         item = shopping_list.items.first
@@ -128,7 +128,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         expect(item.quantity).to eq(ingredients.first.quantity)
       end
 
-      it 'is not crossed off' do
+      it "is not crossed off" do
         ingredient_ids = [ingredients.first.id]
         described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: ingredient_ids)
         item = shopping_list.items.first
@@ -141,14 +141,14 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: ingredient_ids)
         item = shopping_list.items.first
 
-        expect(item.aisle.name).to eq('unassigned')
+        expect(item.aisle.name).to eq("unassigned")
       end
     end
 
-    context 'when an ingredient is already on the shopping list' do
+    context "when an ingredient is already on the shopping list" do
       let(:ingredient) { create(:ingredient) }
       let(:user) { create(:user) }
-      let(:aisle) { create(:aisle, user: user, name: 'rice aisle') }
+      let(:aisle) { create(:aisle, user: user, name: "rice aisle") }
       let(:shopping_list) { create(:shopping_list, user: user) }
       let(:shopping_list_item) do
         create(
@@ -158,23 +158,23 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         )
       end
 
-      context 'and has an aisle assigned' do
-        it 'does not change that aisle assignment' do
+      context "and has an aisle assigned" do
+        it "does not change that aisle assignment" do
           # add item for the first time
           described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: [ingredient.id])
           item = shopping_list.items.last
-          expect(item.aisle.name).to eq('unassigned')
+          expect(item.aisle.name).to eq("unassigned")
 
           # assign an aisle to the item
           item.update!(aisle: aisle)
 
           # add the item for the second time
           described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: [ingredient.id])
-          expect(item.aisle.name).to eq('rice aisle')
+          expect(item.aisle.name).to eq("rice aisle")
         end
       end
 
-      context 'and not marked as crossed-off' do
+      context "and not marked as crossed-off" do
         it "the incoming ingredient's quantity is added to the list item's quantity" do
           # add item for the first time
           described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: [ingredient.id])
@@ -188,7 +188,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
         end
       end
 
-      context 'and marked as crossed-off' do
+      context "and marked as crossed-off" do
         it "the list item's quantity matches the incoming ingredient.quantity" do
           # add item for the first time
           described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: [ingredient.id])
@@ -196,7 +196,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           expect(item.quantity).to eq(ingredient.quantity)
 
           # cross off the item
-          item.update!(status: 'inactive')
+          item.update!(status: "inactive")
           item.reload
 
           # add the item for the second time
@@ -206,14 +206,14 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
           expect(item.quantity).to eq(ingredient.quantity)
         end
 
-        it 'is no longer crossed off' do
+        it "is no longer crossed off" do
           # add item for the first time
           described_class.add_ingredients_to_list(shopping_list: shopping_list, ingredient_ids: [ingredient.id])
           item = shopping_list.items.last
           expect(item.quantity).to eq(ingredient.quantity)
 
           # cross off the item
-          item.update!(status: 'inactive')
+          item.update!(status: "inactive")
           item.reload
 
           # add the item for the second time

--- a/spec/models/shopping_list_item_builder_spec.rb
+++ b/spec/models/shopping_list_item_builder_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list) }
 
       before do
-        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-          incoming_item: incoming_item)
+        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list, incoming_item: incoming_item)
       end
 
       it "creates a new the item" do
@@ -34,8 +33,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 2, name: shopping_list_item.name) }
 
       before do
-        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-          incoming_item: incoming_item)
+        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list, incoming_item: incoming_item)
       end
 
       it "adds the incoming quantity to the existing quantity" do
@@ -50,8 +48,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 1, name: shopping_list_item.name) }
 
       before do
-        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-          incoming_item: incoming_item)
+        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list, incoming_item: incoming_item)
       end
 
       it "sets the item quantity to the incoming quantity" do
@@ -71,8 +68,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
       let(:incoming_item) { build(:shopping_list_item, shopping_list: shopping_list, quantity: 1, name: shopping_list_item.name) }
 
       before do
-        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list,
-          incoming_item: incoming_item)
+        ShoppingListItemBuilder.add_item_to_list(shopping_list: shopping_list, incoming_item: incoming_item)
       end
 
       it "adds the incoming quantity to the existing quantity" do
@@ -89,11 +85,7 @@ RSpec.describe ShoppingListItemBuilder, type: :model do
 
   describe "#add_ingredients_to_list" do
     let(:shopping_list) { create(:shopping_list, main: true) }
-    # let(:meal_plan) { create(:meal_plan) }
-    # let(:recipe) { create(:recipe) }
-    # let(:ingredient) { create(:ingredient, recipe: recipe, quantity: 1, measurement_unit: 'cup', name: 'rice') }
     let(:ingredients) { create_list(:ingredient, 3) }
-    # let(:ingredient_ids) { ingredient.id }
     let(:ingredient_ids) { ingredients.pluck(:id) }
     let!(:aisle) { create(:aisle, name: "Unassigned") }
 

--- a/spec/models/shopping_list_item_recurrence_spec.rb
+++ b/spec/models/shopping_list_item_recurrence_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe ShoppingListItemRecurrence, type: :model do
-  describe 'self.check_schedule' do
-    it 'does not change non-recurring items' do
-      item = create(:shopping_list_item, status: 'inactive', quantity: 1)
+  describe "self.check_schedule" do
+    it "does not change non-recurring items" do
+      item = create(:shopping_list_item, status: "inactive", quantity: 1)
       ShoppingListItemRecurrence.check_schedule
 
       expect(item.active?).to eq(false)
       expect(item.quantity).to eq(1)
     end
 
-    it 'adds recurring items to list on its scheduled day' do
+    it "adds recurring items to list on its scheduled day" do
       allow(ShoppingListItemRecurrence).to receive(:add_weekly_item?).and_return(true)
-      weekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'weekly')
+      weekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "weekly")
 
       allow(ShoppingListItemRecurrence).to receive(:add_biweekly_item?).and_return(true)
-      biweekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'biweekly')
+      biweekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "biweekly")
 
       allow(ShoppingListItemRecurrence).to receive(:add_monthly_item?).and_return(true)
-      monthly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'monthly')
+      monthly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "monthly")
 
       ShoppingListItemRecurrence.check_schedule
 
@@ -27,15 +27,15 @@ RSpec.describe ShoppingListItemRecurrence, type: :model do
       expect(monthly_item.reload.active?).to eq(true)
     end
 
-    it 'does not add recurring items to list on on non-scheduled days' do
+    it "does not add recurring items to list on on non-scheduled days" do
       allow(ShoppingListItemRecurrence).to receive(:add_weekly_item?).and_return(false)
-      weekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'weekly')
+      weekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "weekly")
 
       allow(ShoppingListItemRecurrence).to receive(:add_biweekly_item?).and_return(false)
-      biweekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'biweekly')
+      biweekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "biweekly")
 
       allow(ShoppingListItemRecurrence).to receive(:add_monthly_item?).and_return(false)
-      monthly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'monthly')
+      monthly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "monthly")
 
       ShoppingListItemRecurrence.check_schedule
 
@@ -44,25 +44,25 @@ RSpec.describe ShoppingListItemRecurrence, type: :model do
       expect(monthly_item.reload.active?).to eq(false)
     end
 
-    it 'moves the item to active if the item is inactive' do
+    it "moves the item to active if the item is inactive" do
       allow(ShoppingListItemRecurrence).to receive(:add_weekly_item?).and_return(true)
-      weekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'weekly')
+      weekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "weekly")
       ShoppingListItemRecurrence.check_schedule
 
       expect(weekly_item.reload.active?).to eq(true)
     end
 
-    it 'inserts the recurrence qty as the qty if the item is inactive' do
+    it "inserts the recurrence qty as the qty if the item is inactive" do
       allow(ShoppingListItemRecurrence).to receive(:add_weekly_item?).and_return(true)
-      weekly_item = create(:shopping_list_item, status: 'inactive', recurrence_frequency: 'weekly', quantity: 2, recurrence_quantity: 1)
+      weekly_item = create(:shopping_list_item, status: "inactive", recurrence_frequency: "weekly", quantity: 2, recurrence_quantity: 1)
       ShoppingListItemRecurrence.check_schedule
 
       expect(weekly_item.reload.quantity).to eq(1)
     end
 
-    it 'adds the recurrence qty to the existing qty if is active' do
+    it "adds the recurrence qty to the existing qty if is active" do
       allow(ShoppingListItemRecurrence).to receive(:add_weekly_item?).and_return(true)
-      weekly_item = create(:shopping_list_item, status: 'active', recurrence_frequency: 'weekly', quantity: 2, recurrence_quantity: 1)
+      weekly_item = create(:shopping_list_item, status: "active", recurrence_frequency: "weekly", quantity: 2, recurrence_quantity: 1)
       ShoppingListItemRecurrence.check_schedule
 
       expect(weekly_item.reload.quantity).to eq(3)

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -3,15 +3,15 @@
 RSpec.describe ShoppingListItem, type: :model do
   let(:shopping_list_item) { build(:shopping_list_item) }
 
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:aisle) }
     it { should belong_to(:shopping_list) }
     it { should belong_to(:list) }
   end
 
-  describe 'a valid shopping_list_item' do
-    context 'when has valid params' do
-      it 'is valid' do
+  describe "a valid shopping_list_item" do
+    context "when has valid params" do
+      it "is valid" do
         expect(shopping_list_item).to be_valid
       end
 
@@ -24,10 +24,10 @@ RSpec.describe ShoppingListItem, type: :model do
     end
   end
 
-  context 'scopes' do
-    let(:active_item) { create(:shopping_list_item, status: 'active') }
-    let(:inactive_item) { create(:shopping_list_item, status: 'inactive') }
-    let(:in_cart_item) { create(:shopping_list_item, status: 'in_cart') }
+  context "scopes" do
+    let(:active_item) { create(:shopping_list_item, status: "active") }
+    let(:inactive_item) { create(:shopping_list_item, status: "inactive") }
+    let(:in_cart_item) { create(:shopping_list_item, status: "in_cart") }
 
     before do
       active_item
@@ -35,50 +35,50 @@ RSpec.describe ShoppingListItem, type: :model do
       in_cart_item
     end
 
-    describe 'active' do
-      it 'returns only active items' do
+    describe "active" do
+      it "returns only active items" do
         expect(described_class.active).to include(active_item)
       end
 
-      it 'does not return items without the status of active' do
+      it "does not return items without the status of active" do
         expect(described_class.active).to_not include(inactive_item)
         expect(described_class.active).to_not include(in_cart_item)
       end
     end
 
-    describe 'inactive' do
-      it 'returns only inactive items' do
+    describe "inactive" do
+      it "returns only inactive items" do
         expect(described_class.inactive).to include(inactive_item)
       end
 
-      it 'does not return items without the status of inactive' do
+      it "does not return items without the status of inactive" do
         expect(described_class.inactive).to_not include(active_item)
         expect(described_class.inactive).to_not include(in_cart_item)
       end
     end
 
-    describe 'not_purchased' do
-      it 'returns active items items' do
+    describe "not_purchased" do
+      it "returns active items items" do
         expect(described_class.not_purchased).to include(active_item)
       end
 
-      it 'returns in_cart items items' do
+      it "returns in_cart items items" do
         expect(described_class.not_purchased).to include(in_cart_item)
       end
 
-      it 'does not return inactive items' do
+      it "does not return inactive items" do
         expect(described_class.not_purchased).to_not include(inactive_item)
       end
     end
   end
 
-  describe 'self.by_recently_edited' do
-    it 'returns the most recently editied item first' do
+  describe "self.by_recently_edited" do
+    it "returns the most recently editied item first" do
       create(:shopping_list_item)
       item2 = create(:shopping_list_item)
       create(:shopping_list_item)
 
-      item2.status = 'inactive'
+      item2.status = "inactive"
       item2.save
 
       ordered_items = ShoppingListItem.by_recently_edited
@@ -87,15 +87,15 @@ RSpec.describe ShoppingListItem, type: :model do
     end
   end
 
-  describe 'self.by_aisle_order_number' do
+  describe "self.by_aisle_order_number" do
     it "orders based on the associated aisle's order_number then by item name" do
-      second_aisle = create(:aisle, name: 'second aisle', order_number: 2)
-      first_aisle = create(:aisle, name: 'first aisle', order_number: 1)
+      second_aisle = create(:aisle, name: "second aisle", order_number: 2)
+      first_aisle = create(:aisle, name: "first aisle", order_number: 1)
 
-      list = create(:shopping_list, name: 'list')
-      third_item = create(:shopping_list_item, name: 'carrots', shopping_list_id: list.id, aisle_id: second_aisle.id)
-      second_item = create(:shopping_list_item, name: 'bananas', shopping_list_id: list.id, aisle_id: second_aisle.id)
-      first_item = create(:shopping_list_item, name: 'apples', shopping_list_id: list.id, aisle_id: first_aisle.id)
+      list = create(:shopping_list, name: "list")
+      third_item = create(:shopping_list_item, name: "carrots", shopping_list_id: list.id, aisle_id: second_aisle.id)
+      second_item = create(:shopping_list_item, name: "bananas", shopping_list_id: list.id, aisle_id: second_aisle.id)
+      first_item = create(:shopping_list_item, name: "apples", shopping_list_id: list.id, aisle_id: first_aisle.id)
 
       aggregate_failures("verifying item order") do
         expect(list.shopping_list_items.by_aisle_order_number[0]).to eq(first_item)
@@ -105,60 +105,60 @@ RSpec.describe ShoppingListItem, type: :model do
     end
   end
 
-  describe '#active?' do
+  describe "#active?" do
     it 'returns true if the status is "active"' do
-      item = build(:shopping_list_item, status: 'active')
+      item = build(:shopping_list_item, status: "active")
       expect(item.active?).to eq(true)
     end
 
     it 'returns false if the status is not "active"' do
-      item = build(:shopping_list_item, status: 'anything')
+      item = build(:shopping_list_item, status: "anything")
       expect(item.active?).to eq(false)
     end
   end
 
-  describe '#inactive?' do
+  describe "#inactive?" do
     it 'returns true if the status is "inactive"' do
-      item = build(:shopping_list_item, status: 'inactive')
+      item = build(:shopping_list_item, status: "inactive")
       expect(item.inactive?).to eq(true)
     end
 
     it 'returns false if the status is not "inactive"' do
-      item = build(:shopping_list_item, status: 'anything')
+      item = build(:shopping_list_item, status: "anything")
       expect(item.inactive?).to eq(false)
     end
   end
 
-  describe '#in_cart?' do
+  describe "#in_cart?" do
     it 'returns true if the status is "in_cart"' do
-      item = build(:shopping_list_item, status: 'in_cart')
+      item = build(:shopping_list_item, status: "in_cart")
       expect(item.in_cart?).to eq(true)
     end
 
     it 'returns false if the status is not "in_cart"' do
-      item = build(:shopping_list_item, status: 'anything')
+      item = build(:shopping_list_item, status: "anything")
       expect(item.in_cart?).to eq(false)
     end
   end
 
-  describe '#deactivate!' do
+  describe "#deactivate!" do
     it 'sets the status attribute to "inactive" and saves the item' do
-      item = build(:shopping_list_item, status: 'active')
-      expect { item.deactivate! }.to change { item.status }.from('active').to('inactive')
+      item = build(:shopping_list_item, status: "active")
+      expect { item.deactivate! }.to change { item.status }.from("active").to("inactive")
     end
   end
 
-  describe '#activate!' do
+  describe "#activate!" do
     it 'sets the "status" attribute to "active" and saves the item' do
-      item = build(:shopping_list_item, status: 'inactive')
-      expect { item.activate! }.to change { item.status }.from('inactive').to('active')
+      item = build(:shopping_list_item, status: "inactive")
+      expect { item.activate! }.to change { item.status }.from("inactive").to("active")
     end
   end
 
-  describe '#add_to_cart!' do
+  describe "#add_to_cart!" do
     it 'sets the "status" attribute to "in_cart" and saves the item' do
-      item = build(:shopping_list_item, status: 'active')
-      expect { item.add_to_cart! }.to change { item.status }.from('active').to('in_cart')
+      item = build(:shopping_list_item, status: "active")
+      expect { item.add_to_cart! }.to change { item.status }.from("active").to("in_cart")
     end
   end
 end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -3,42 +3,42 @@
 RSpec.describe ShoppingList, type: :model do
   let(:shopping_list) { build(:shopping_list) }
 
-  context 'associations' do
+  context "associations" do
     it { should belong_to(:user) }
     it { should have_many(:shopping_list_items) }
     it { should have_many(:items) }
     it { should have_many(:scheduled_deliveries) }
   end
 
-  describe 'a valid shopping_list' do
-    context 'when has valid params' do
-      it 'is valid' do
+  describe "a valid shopping_list" do
+    context "when has valid params" do
+      it "is valid" do
         expect(shopping_list).to be_valid
       end
 
       it { should validate_presence_of(:name) }
 
-      it 'validates that names are unique' do
-        create(:shopping_list, name: 'grocery')
+      it "validates that names are unique" do
+        create(:shopping_list, name: "grocery")
         should validate_uniqueness_of(:name).case_insensitive
       end
     end
   end
 
-  describe 'self.default' do
+  describe "self.default" do
     let(:user) { create(:user) }
     let(:shopping_list) { create(:shopping_list, user: user) }
 
     it 'returns the existing shopping list called "grocery" that belongs to the current_user' do
-      existing_list = create(:shopping_list, user: user, name: 'grocery', main: true)
+      existing_list = create(:shopping_list, user: user, name: "grocery", main: true)
       returned_list = user.shopping_lists.default
 
       expect(returned_list).to eq(existing_list)
     end
   end
 
-  describe '.by_favorite' do
-    it 'returns results with the favorite first' do
+  describe ".by_favorite" do
+    it "returns results with the favorite first" do
       favorite_list = create(:shopping_list, favorite: true)
       create(:shopping_list, favorite: false)
       ordered_lists = ShoppingList.by_favorite
@@ -47,7 +47,7 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  describe '#favorite!' do
+  describe "#favorite!" do
     it 'sets the "favorite" attribute to true and saves the list' do
       list = create(:shopping_list, favorite: false)
       list.favorite!
@@ -56,7 +56,7 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  describe '#unfavorite!' do
+  describe "#unfavorite!" do
     it 'sets the "favorite" attribute to false and saves the list' do
       list = create(:shopping_list, favorite: true)
       list.unfavorite!
@@ -65,25 +65,25 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  describe 'default?' do
+  describe "default?" do
     it 'returns true if it is the "main" list' do
       list = build(:shopping_list, main: true)
       expect(list.default?).to be(true)
     end
 
-    it 'returns false if it is any other list' do
+    it "returns false if it is any other list" do
       list = build(:shopping_list)
       expect(list.default?).to be(false)
     end
   end
 
-  describe 'deletable?' do
+  describe "deletable?" do
     it 'returns false if it is the "main" list' do
       list = build(:shopping_list, main: true)
       expect(list.deletable?).to be(false)
     end
 
-    it 'returns true if it is any other list' do
+    it "returns true if it is any other list" do
       list = build(:shopping_list)
       expect(list.deletable?).to be(true)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   let(:user) { build(:user) }
 
-  context 'associations' do
+  context "associations" do
     it { should have_many(:recipes) }
     it { should have_many(:experimental_recipes) }
     it { should have_many(:meal_plans) }
@@ -13,16 +13,16 @@ RSpec.describe User, type: :model do
     it { should have_many(:aisles) }
   end
 
-  describe '#favorite_list' do
+  describe "#favorite_list" do
     let(:user) { create(:user) }
     let!(:fave_list) { create(:shopping_list, user: user, favorite: true) }
     let!(:other_list) { create(:shopping_list, user: user, favorite: false) }
 
-    it 'returns a single shopping list' do
+    it "returns a single shopping list" do
       expect(user.favorite_list.class).to eq(ShoppingList)
     end
 
-    it 'returns a shopping_list that is marked as favorite for this user' do
+    it "returns a shopping_list that is marked as favorite for this user" do
       expect(user.favorite_list).to eq(fave_list)
       expect(user.favorite_list).not_to eq(other_list)
     end

--- a/spec/policies/meal_plan_policy_spec.rb
+++ b/spec/policies/meal_plan_policy_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe MealPlanPolicy, type: :policy do
   let(:user) { create(:user) }
@@ -9,105 +9,105 @@ RSpec.describe MealPlanPolicy, type: :policy do
   subject { MealPlanPolicy }
 
   permissions :show? do
-    it 'denies access to visitors' do
+    it "denies access to visitors" do
       no_user = nil
       expect(subject).not_to permit(no_user, meal_plan)
     end
 
-    it 'denies access to non-author users' do
+    it "denies access to non-author users" do
       different_user = create(:user)
       expect(subject).not_to permit(different_user, meal_plan)
     end
 
-    it 'permits access to author users' do
+    it "permits access to author users" do
       expect(subject).to permit(user, meal_plan)
     end
 
-    it 'permits access to non-author admin users' do
+    it "permits access to non-author admin users" do
       admin = create(:user, admin: true)
       expect(subject).to permit(admin, meal_plan)
     end
   end
 
   permissions :create? do
-    it 'denies access to visitors' do
+    it "denies access to visitors" do
       no_user = nil
       expect(subject).not_to permit(no_user, meal_plan)
     end
 
-    it 'denies access to non-author users' do
+    it "denies access to non-author users" do
       different_user = create(:user)
       expect(subject).not_to permit(different_user, meal_plan)
     end
 
-    it 'permits access to author users' do
+    it "permits access to author users" do
       expect(subject).to permit(user, meal_plan)
     end
 
-    it 'permits access to non-author admin users' do
+    it "permits access to non-author admin users" do
       admin = create(:user, admin: true)
       expect(subject).to permit(admin, meal_plan)
     end
   end
 
   permissions :edit? do
-    it 'denies access to visitors' do
+    it "denies access to visitors" do
       no_user = nil
       expect(subject).not_to permit(no_user, meal_plan)
     end
 
-    it 'denies access to non-author users' do
+    it "denies access to non-author users" do
       different_user = create(:user)
       expect(subject).not_to permit(different_user, meal_plan)
     end
 
-    it 'permits access to author users' do
+    it "permits access to author users" do
       expect(subject).to permit(user, meal_plan)
     end
 
-    it 'permits access to non-author admin users' do
+    it "permits access to non-author admin users" do
       admin = create(:user, admin: true)
       expect(subject).to permit(admin, meal_plan)
     end
   end
 
   permissions :update? do
-    it 'denies access to visitors' do
+    it "denies access to visitors" do
       no_user = nil
       expect(subject).not_to permit(no_user, meal_plan)
     end
 
-    it 'denies access to non-author users' do
+    it "denies access to non-author users" do
       different_user = create(:user)
       expect(subject).not_to permit(different_user, meal_plan)
     end
 
-    it 'permits access to author users' do
+    it "permits access to author users" do
       expect(subject).to permit(user, meal_plan)
     end
 
-    it 'permits access to non-author admin users' do
+    it "permits access to non-author admin users" do
       admin = create(:user, admin: true)
       expect(subject).to permit(admin, meal_plan)
     end
   end
 
   permissions :destroy? do
-    it 'denies access to visitors' do
+    it "denies access to visitors" do
       no_user = nil
       expect(subject).not_to permit(no_user, meal_plan)
     end
 
-    it 'denies access to non-author users' do
+    it "denies access to non-author users" do
       different_user = create(:user)
       expect(subject).not_to permit(different_user, meal_plan)
     end
 
-    it 'permits access to author users' do
+    it "permits access to author users" do
       expect(subject).to permit(user, meal_plan)
     end
 
-    it 'permits access to non-author admin users' do
+    it "permits access to non-author admin users" do
       admin = create(:user, admin: true)
       expect(subject).to permit(admin, meal_plan)
     end

--- a/spec/policies/shopping_list_policy_spec.rb
+++ b/spec/policies/shopping_list_policy_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ShoppingListPolicy, type: :policy do
   let(:author) { create(:user) }
@@ -10,24 +10,24 @@ RSpec.describe ShoppingListPolicy, type: :policy do
   subject { ShoppingListPolicy }
 
   permissions :show? do
-    describe 'denies access to...' do
-      it 'visitors' do
+    describe "denies access to..." do
+      it "visitors" do
         no_user = nil
         expect(subject).not_to permit(no_user, shopping_list)
       end
 
-      it 'non-author users' do
+      it "non-author users" do
         different_user = create(:user)
         expect(subject).not_to permit(different_user, shopping_list)
       end
     end
 
-    describe 'permits access to...' do
-      it 'author users' do
+    describe "permits access to..." do
+      it "author users" do
         expect(subject).to permit(author, shopping_list)
       end
 
-      it 'non-author admin users' do
+      it "non-author admin users" do
         # admin = create(:user, admin: true)
         expect(subject).to permit(admin, shopping_list)
       end
@@ -35,24 +35,24 @@ RSpec.describe ShoppingListPolicy, type: :policy do
   end
 
   permissions :create? do
-    describe 'denies access to...' do
-      it 'visitors' do
+    describe "denies access to..." do
+      it "visitors" do
         no_user = nil
         expect(subject).not_to permit(no_user, shopping_list)
       end
 
-      it 'non-author users' do
+      it "non-author users" do
         different_user = create(:user)
         expect(subject).not_to permit(different_user, shopping_list)
       end
     end
 
-    describe 'permits access to...' do
-      it 'author users' do
+    describe "permits access to..." do
+      it "author users" do
         expect(subject).to permit(author, shopping_list)
       end
 
-      it 'non-author admin users' do
+      it "non-author admin users" do
         # admin = create(:user, admin: true)
         expect(subject).to permit(admin, shopping_list)
       end
@@ -60,24 +60,24 @@ RSpec.describe ShoppingListPolicy, type: :policy do
   end
 
   permissions :edit? do
-    describe 'denies access to...' do
-      it 'visitors' do
+    describe "denies access to..." do
+      it "visitors" do
         no_user = nil
         expect(subject).not_to permit(no_user, shopping_list)
       end
 
-      it 'non-author users' do
+      it "non-author users" do
         different_user = create(:user)
         expect(subject).not_to permit(different_user, shopping_list)
       end
     end
 
-    describe 'permits access to...' do
-      it 'author users' do
+    describe "permits access to..." do
+      it "author users" do
         expect(subject).to permit(author, shopping_list)
       end
 
-      it 'non-author admin users' do
+      it "non-author admin users" do
         # admin = create(:user, admin: true)
         expect(subject).to permit(admin, shopping_list)
       end
@@ -85,24 +85,24 @@ RSpec.describe ShoppingListPolicy, type: :policy do
   end
 
   permissions :update? do
-    describe 'denies access to...' do
-      it 'visitors' do
+    describe "denies access to..." do
+      it "visitors" do
         no_user = nil
         expect(subject).not_to permit(no_user, shopping_list)
       end
 
-      it 'non-author users' do
+      it "non-author users" do
         different_user = create(:user)
         expect(subject).not_to permit(different_user, shopping_list)
       end
     end
 
-    describe 'permits access to...' do
-      it 'author users' do
+    describe "permits access to..." do
+      it "author users" do
         expect(subject).to permit(author, shopping_list)
       end
 
-      it 'non-author admin users' do
+      it "non-author admin users" do
         # admin = create(:user, admin: true)
         expect(subject).to permit(admin, shopping_list)
       end
@@ -110,24 +110,24 @@ RSpec.describe ShoppingListPolicy, type: :policy do
   end
 
   permissions :destroy? do
-    describe 'it denies access to...' do
-      it 'visitors' do
+    describe "it denies access to..." do
+      it "visitors" do
         no_user = nil
         expect(subject).not_to permit(no_user, shopping_list)
       end
 
-      it 'non-author users' do
+      it "non-author users" do
         different_user = create(:user)
         expect(subject).not_to permit(different_user, shopping_list)
       end
     end
 
-    describe 'it permits access to...' do
-      it 'author users' do
+    describe "it permits access to..." do
+      it "author users" do
         expect(subject).to permit(author, shopping_list)
       end
 
-      it 'non-author admin users' do
+      it "non-author admin users" do
         # admin = create(:user, admin: true)
         expect(subject).to permit(admin, shopping_list)
       end
@@ -136,16 +136,16 @@ RSpec.describe ShoppingListPolicy, type: :policy do
     describe 'default shopping list ("Grocery")' do
       let(:default_shopping_list) { create(:shopping_list, user: author, main: true) }
 
-      it 'it denies authors' do
+      it "it denies authors" do
         expect(subject).not_to permit(author, default_shopping_list)
       end
 
-      it 'denies non-author admin' do
+      it "denies non-author admin" do
         # admin = create(:user, admin: true)
         expect(subject).not_to permit(admin, default_shopping_list)
       end
 
-      it 'denies author admin' do
+      it "denies author admin" do
         admin_author = create(:user, admin: true)
         default_shopping_list = create(:shopping_list, user: admin_author, main: true)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'rspec/rails'
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'pry'
-require 'devise'
-require 'capybara/rails'
-require 'capybara/rspec'
-require 'pundit/rspec'
-require 'webdrivers'
-require 'support/factory_bot'
-require 'support/capybara'
-require 'support/shoulda_matchers'
+require "pry"
+require "devise"
+require "capybara/rails"
+require "capybara/rspec"
+require "pundit/rspec"
+require "webdrivers"
+require "support/factory_bot"
+require "support/capybara"
+require "support/shoulda_matchers"
 
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
@@ -27,7 +27,6 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
-
 
 RSpec.configure do |config|
   config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]

--- a/spec/requests/aisles_spec.rb
+++ b/spec/requests/aisles_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Aisles', type: :request do
-  describe 'Public access to aisles' do
+RSpec.describe "Aisles", type: :request do
+  describe "Public access to aisles" do
     let(:user) { create(:user) }
     let(:user_aisle) { create(:aisle, user: user) }
 
@@ -11,28 +11,28 @@ RSpec.describe 'Aisles', type: :request do
       user_aisle
     end
 
-    it 'denies access to aisles#index' do
+    it "denies access to aisles#index" do
       get aisles_path
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to aisles#new' do
+    it "denies access to aisles#new" do
       get new_aisle_path
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to aisles#edit' do
+    it "denies access to aisles#edit" do
       get edit_aisle_path(user_aisle.id)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to aisles#create' do
+    it "denies access to aisles#create" do
       aisle_attributes = build(:aisle, user: user).attributes
 
       expect {
@@ -43,14 +43,14 @@ RSpec.describe 'Aisles', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to aisles#update' do
+    it "denies access to aisles#update" do
       patch aisle_path(user_aisle, aisle: user_aisle.attributes)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to aisles#destroy' do
+    it "denies access to aisles#destroy" do
       delete aisle_path(user_aisle)
 
       expect(response).to have_http_status(302)
@@ -58,7 +58,7 @@ RSpec.describe 'Aisles', type: :request do
     end
   end
 
-  describe 'Authenticated access to own aisles' do
+  describe "Authenticated access to own aisles" do
     let(:user) { create(:user) }
     let(:user_aisle) { create(:aisle, user: user) }
 
@@ -67,21 +67,21 @@ RSpec.describe 'Aisles', type: :request do
       sign_in(user)
     end
 
-    it 'renders aisles#new' do
+    it "renders aisles#new" do
       get new_aisle_path
 
       expect(response).to be_successful
       expect(response).to render_template(:new)
     end
 
-    it 'renders aisles#edit' do
+    it "renders aisles#edit" do
       get edit_aisle_path(user_aisle.id)
 
       expect(response).to be_successful
       expect(response).to render_template(:edit)
     end
 
-    it 'renders aisles#create' do
+    it "renders aisles#create" do
       starting_count = Aisle.count
       aisle_attributes = build(:aisle, user: user).attributes
       post aisles_path(aisle: aisle_attributes)
@@ -89,14 +89,14 @@ RSpec.describe 'Aisles', type: :request do
       expect(Aisle.count).to eq(starting_count + 1)
     end
 
-    it 'renders aisles#update' do
-      new_name = 'different name'
-      patch aisle_path(user_aisle, aisle: { name: new_name })
+    it "renders aisles#update" do
+      new_name = "different name"
+      patch aisle_path(user_aisle, aisle: {name: new_name})
 
       expect(response).to redirect_to aisles_url
     end
 
-    it 'renders aisles#destroy' do
+    it "renders aisles#destroy" do
       delete aisle_path(user_aisle)
 
       expect(response).to redirect_to(aisles_url)
@@ -113,7 +113,7 @@ RSpec.describe 'Aisles', type: :request do
       sign_in(user1)
     end
 
-    it 'denies access to aisles#edit' do
+    it "denies access to aisles#edit" do
       get edit_aisle_path(user2_aisle.id)
 
       expect(response).to_not be_successful
@@ -121,15 +121,15 @@ RSpec.describe 'Aisles', type: :request do
       expect(response).to redirect_to(root_url)
     end
 
-    it 'denies access to aisles#update' do
-      new_name = 'completely different name'
-      patch aisle_path(user2_aisle, aisle: { name: new_name })
+    it "denies access to aisles#update" do
+      new_name = "completely different name"
+      patch aisle_path(user2_aisle, aisle: {name: new_name})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to aisles#destroy' do
+    it "denies access to aisles#destroy" do
       delete aisle_path(user2_aisle)
 
       expect(response).to_not be_successful

--- a/spec/requests/experimental_recipes_spec.rb
+++ b/spec/requests/experimental_recipes_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'ExperimentalRecipes', type: :request do
-  describe 'Public access to experimental_recipes' do
+RSpec.describe "ExperimentalRecipes", type: :request do
+  describe "Public access to experimental_recipes" do
     let(:user) { create(:user) }
     let(:experimental_recipe) { create(:experimental_recipe, user_id: user.id) }
 
@@ -12,22 +12,22 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       experimental_recipe
     end
 
-    it 'denies access to experimental_recipes#index' do
+    it "denies access to experimental_recipes#index" do
       get experimental_recipes_path
       expect(response).to have_http_status(302)
     end
 
-    it 'denies access to experimental_recipes#new' do
+    it "denies access to experimental_recipes#new" do
       get new_experimental_recipe_path
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to experimental_recipes#edit' do
+    it "denies access to experimental_recipes#edit" do
       get edit_experimental_recipe_path(experimental_recipe.id)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to experimental_recipes#create' do
+    it "denies access to experimental_recipes#create" do
       experimental_recipe_attributes = build(:experimental_recipe, user_id: user.id).attributes
 
       expect {
@@ -37,18 +37,18 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to experimental_recipes#update' do
+    it "denies access to experimental_recipes#update" do
       patch experimental_recipe_path(experimental_recipe, experimental_recipe: experimental_recipe.attributes)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to experimental_recipes#destroy' do
+    it "denies access to experimental_recipes#destroy" do
       delete experimental_recipe_path(experimental_recipe)
       expect(response).to redirect_to new_user_session_path
     end
   end
 
-  describe 'Authenticated access to own experimental_recipes' do
+  describe "Authenticated access to own experimental_recipes" do
     let(:user) { create(:user) }
     let(:experimental_recipe) { create(:experimental_recipe, user_id: user.id) }
 
@@ -58,14 +58,14 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       sign_in(user)
     end
 
-    it 'renders experimental_recipes#new' do
+    it "renders experimental_recipes#new" do
       get new_experimental_recipe_path
 
       expect(response).to be_successful
       expect(response).to render_template(:new)
     end
 
-    it 'renders experimental_recipes#edit' do
+    it "renders experimental_recipes#edit" do
       get edit_experimental_recipe_path(experimental_recipe.id)
 
       expect(response).to be_successful
@@ -73,7 +73,7 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       expect(response.body).to include(experimental_recipe.title)
     end
 
-    it 'renders experimental_recipes#create' do
+    it "renders experimental_recipes#create" do
       experimental_recipe_attributes = build(:experimental_recipe, user: user).attributes
 
       expect {
@@ -81,14 +81,14 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       }.to change(ExperimentalRecipe, :count)
     end
 
-    it 'renders experimental_recipes#update' do
-      new_title = 'completely different title'
-      patch experimental_recipe_path(experimental_recipe, experimental_recipe: { title: new_title })
+    it "renders experimental_recipes#update" do
+      new_title = "completely different title"
+      patch experimental_recipe_path(experimental_recipe, experimental_recipe: {title: new_title})
 
       expect(response).to redirect_to experimental_recipes_url
     end
 
-    it 'renders experimental_recipes#destroy' do
+    it "renders experimental_recipes#destroy" do
       delete experimental_recipe_path(experimental_recipe)
 
       expect(response).to redirect_to experimental_recipes_url
@@ -108,22 +108,22 @@ RSpec.describe 'ExperimentalRecipes', type: :request do
       sign_in(user)
     end
 
-    it 'denies access to experimental_recipes#edit' do
+    it "denies access to experimental_recipes#edit" do
       get edit_experimental_recipe_path(others_experimental_recipe.id)
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to experimental_recipes#update' do
-      new_title = 'completely different title'
-      patch experimental_recipe_path(others_experimental_recipe, experimental_recipe: { title: new_title })
+    it "denies access to experimental_recipes#update" do
+      new_title = "completely different title"
+      patch experimental_recipe_path(others_experimental_recipe, experimental_recipe: {title: new_title})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to experimental_recipes#destroy' do
+    it "denies access to experimental_recipes#destroy" do
       delete experimental_recipe_path(others_experimental_recipe)
 
       expect(response).to_not be_successful

--- a/spec/requests/inventories_spec.rb
+++ b/spec/requests/inventories_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Inventories', type: :request do
-  describe 'Public access to inventories' do
+RSpec.describe "Inventories", type: :request do
+  describe "Public access to inventories" do
     let(:user) { create(:user) }
     let(:user_inventory) { create(:inventory, user: user) }
 
@@ -11,14 +11,14 @@ RSpec.describe 'Inventories', type: :request do
       user_inventory
     end
 
-    it 'denies access to inventories#edit' do
+    it "denies access to inventories#edit" do
       get edit_inventory_path(user_inventory.id)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to inventories#update' do
+    it "denies access to inventories#update" do
       patch inventory_path(user_inventory, inventory: user_inventory.attributes)
 
       expect(response).to have_http_status(302)
@@ -26,7 +26,7 @@ RSpec.describe 'Inventories', type: :request do
     end
   end
 
-  describe 'Authenticated access to own inventories' do
+  describe "Authenticated access to own inventories" do
     let(:user) { create(:user) }
     let(:user_inventory) { create(:inventory, user: user) }
 
@@ -35,16 +35,16 @@ RSpec.describe 'Inventories', type: :request do
       sign_in(user)
     end
 
-    it 'renders inventories#edit' do
+    it "renders inventories#edit" do
       get edit_inventory_path(user_inventory.id)
 
       expect(response).to be_successful
       expect(response).to render_template(:edit)
     end
 
-    it 'renders inventories#update' do
-      new_items = 'different items'
-      patch inventory_path(user_inventory, inventory: { items: new_items })
+    it "renders inventories#update" do
+      new_items = "different items"
+      patch inventory_path(user_inventory, inventory: {items: new_items})
 
       expect(response).to redirect_to inventory_recipe_suggestions_path(user_inventory.id)
     end
@@ -60,7 +60,7 @@ RSpec.describe 'Inventories', type: :request do
       sign_in(user1)
     end
 
-    it 'denies access to inventories#edit' do
+    it "denies access to inventories#edit" do
       get edit_inventory_path(user2_inventory.id)
 
       expect(response).to_not be_successful
@@ -68,9 +68,9 @@ RSpec.describe 'Inventories', type: :request do
       expect(response).to redirect_to(root_url)
     end
 
-    it 'denies access to inventories#update' do
-      new_items = 'completely different items'
-      patch inventory_path(user2_inventory, inventory: { items: new_items })
+    it "denies access to inventories#update" do
+      new_items = "completely different items"
+      patch inventory_path(user2_inventory, inventory: {items: new_items})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'MealPlans', type: :request do
-  describe 'Public access to meal_plans' do
+RSpec.describe "MealPlans", type: :request do
+  describe "Public access to meal_plans" do
     let(:user) { create(:user) }
     let(:user_recipe) { create(:recipe, user: user) }
     let(:user_meal_plan) { create(:meal_plan, user_id: user.id) }
@@ -12,29 +12,29 @@ RSpec.describe 'MealPlans', type: :request do
       user_meal_plan.recipes.push(user_recipe)
     end
 
-    it 'denies access to meal_plans#show' do
+    it "denies access to meal_plans#show" do
       get meal_plan_path(user_meal_plan)
 
       expect(response).to have_http_status(302)
       expect(response).to have_http_status(302)
     end
 
-    it 'denies access to meal_plans#index' do
+    it "denies access to meal_plans#index" do
       get meal_plans_path
       expect(response).to have_http_status(302)
     end
 
-    it 'denies access to meal_plans#new' do
+    it "denies access to meal_plans#new" do
       get new_meal_plan_path
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to meal_plans#edit' do
+    it "denies access to meal_plans#edit" do
       get edit_meal_plan_path(user_meal_plan.id)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to meal_plans#create' do
+    it "denies access to meal_plans#create" do
       meal_plan_attributes = build(:meal_plan, user: user).attributes
 
       expect {
@@ -44,18 +44,18 @@ RSpec.describe 'MealPlans', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to meal_plans#update' do
+    it "denies access to meal_plans#update" do
       patch meal_plan_path(user_meal_plan, meal_plan: user_meal_plan.attributes)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to meal_plans#destroy' do
+    it "denies access to meal_plans#destroy" do
       delete meal_plan_path(user_meal_plan)
       expect(response).to redirect_to new_user_session_path
     end
   end
 
-  describe 'Authenticated access to own meal_plans' do
+  describe "Authenticated access to own meal_plans" do
     let(:user) { create(:user) }
     let(:user_recipe) { create(:recipe, user: user) }
     let(:user_meal_plan) { create(:meal_plan, user_id: user.id) }
@@ -65,30 +65,30 @@ RSpec.describe 'MealPlans', type: :request do
       sign_in user
     end
 
-    it 'renders meal_plans#show' do
+    it "renders meal_plans#show" do
       get meal_plan_path(user_meal_plan)
 
       expect(response).to be_successful
       expect(response).to have_http_status(200)
     end
 
-    it 'renders meal_plans#new' do
+    it "renders meal_plans#new" do
       get new_meal_plan_path
 
       expect(response).to be_successful
       expect(response).to render_template(:new)
     end
 
-    it 'renders meal_plans#edit' do
+    it "renders meal_plans#edit" do
       get edit_meal_plan_path(user_meal_plan.id)
 
       expect(response).to be_successful
       expect(response).to render_template(:edit)
     end
 
-    describe '#create' do
-      context 'when the save is successful' do
-        it 'creates a new record' do
+    describe "#create" do
+      context "when the save is successful" do
+        it "creates a new record" do
           starting_count = MealPlan.count
           meal_plan_attributes = build(:meal_plan, user: user).attributes
           post meal_plans_path(meal_plan: meal_plan_attributes)
@@ -96,7 +96,7 @@ RSpec.describe 'MealPlans', type: :request do
           expect(MealPlan.count).to eq(starting_count + 1)
         end
 
-        it 'redirects to the new record' do
+        it "redirects to the new record" do
           meal_plan_attributes = build(:meal_plan, user: user).attributes
           post meal_plans_path(meal_plan: meal_plan_attributes)
 
@@ -104,10 +104,10 @@ RSpec.describe 'MealPlans', type: :request do
         end
       end
 
-      context 'when the save is unsuccessful' do
-        it 'renders :new' do
-          same_date = '2024-04-01'
-          existing_meal_plan = create(:meal_plan, prepared_on: same_date, user: user)
+      context "when the save is unsuccessful" do
+        it "renders :new" do
+          same_date = "2024-04-01"
+          create(:meal_plan, prepared_on: same_date, user: user)
           meal_plan_attributes = build(:meal_plan, prepared_on: same_date, user: user).attributes
           post meal_plans_path(meal_plan: meal_plan_attributes)
 
@@ -116,28 +116,28 @@ RSpec.describe 'MealPlans', type: :request do
       end
     end
 
-    describe '#update' do
-      context 'when the update is successful' do
-        it 'redirects to the meal_plan' do
+    describe "#update" do
+      context "when the update is successful" do
+        it "redirects to the meal_plan" do
           new_prepared_on = Time.zone.now + 15
-          patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: new_prepared_on })
+          patch meal_plan_path(user_meal_plan, meal_plan: {prepared_on: new_prepared_on})
 
           expect(response).to redirect_to meal_plan_url(user_meal_plan)
         end
       end
 
-      context 'when the update is unsuccessful' do
-        it 'redirects to the meal_plan' do
-          same_date = '2024-04-01'
-          existing_meal_plan = create(:meal_plan, prepared_on: same_date, user: user)
-          patch meal_plan_path(user_meal_plan, meal_plan: { prepared_on: same_date })
+      context "when the update is unsuccessful" do
+        it "redirects to the meal_plan" do
+          same_date = "2024-04-01"
+          create(:meal_plan, prepared_on: same_date, user: user)
+          patch meal_plan_path(user_meal_plan, meal_plan: {prepared_on: same_date})
 
           expect(response).to render_template(:edit)
         end
       end
     end
 
-    it 'renders meal_plans#destroy' do
+    it "renders meal_plans#destroy" do
       delete meal_plan_path(user_meal_plan)
 
       expect(response).to redirect_to meal_plans_url
@@ -155,29 +155,29 @@ RSpec.describe 'MealPlans', type: :request do
       sign_in user1
     end
 
-    it 'denies access to meal_plans#show' do
+    it "denies access to meal_plans#show" do
       get meal_plan_path(user2_meal_plan.id)
 
       expect(response).to_not be_successful
       expect(response).to have_http_status(302)
     end
 
-    it 'denies access to meal_plans#edit' do
+    it "denies access to meal_plans#edit" do
       get edit_meal_plan_path(user2_meal_plan.id)
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to meal_plans#update' do
-      new_prepared_on = 'completely different prepared_on'
-      patch meal_plan_path(user2_meal_plan, meal_plan: { prepared_on: new_prepared_on })
+    it "denies access to meal_plans#update" do
+      new_prepared_on = "completely different prepared_on"
+      patch meal_plan_path(user2_meal_plan, meal_plan: {prepared_on: new_prepared_on})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to meal_plans#destroy' do
+    it "denies access to meal_plans#destroy" do
       delete meal_plan_path(user2_meal_plan)
 
       expect(response).to_not be_successful

--- a/spec/requests/recipe_suggestions_spec.rb
+++ b/spec/requests/recipe_suggestions_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'RecipeSuggestions', type: :request do
-  describe 'Public access to recipe_suggestions' do
+RSpec.describe "RecipeSuggestions", type: :request do
+  describe "Public access to recipe_suggestions" do
     let(:user) { create(:user) }
     let(:user_inventory) { create(:inventory, user: user) }
 
@@ -11,7 +11,7 @@ RSpec.describe 'RecipeSuggestions', type: :request do
       user_inventory
     end
 
-    it 'denies access to inventory_recipe_suggestions#index' do
+    it "denies access to inventory_recipe_suggestions#index" do
       get inventory_recipe_suggestions_path(user_inventory.id)
 
       expect(response).to have_http_status(302)
@@ -19,7 +19,7 @@ RSpec.describe 'RecipeSuggestions', type: :request do
     end
   end
 
-  describe 'Authenticated access to own recipe_suggestions' do
+  describe "Authenticated access to own recipe_suggestions" do
     let(:user) { create(:user) }
     let(:user_inventory) { create(:inventory, user: user) }
 
@@ -28,7 +28,7 @@ RSpec.describe 'RecipeSuggestions', type: :request do
       sign_in(user)
     end
 
-    it 'renders recipe_suggestions#index' do
+    it "renders recipe_suggestions#index" do
       get inventory_recipe_suggestions_path(user_inventory.id)
 
       expect(response).to have_http_status(200)
@@ -46,7 +46,7 @@ RSpec.describe 'RecipeSuggestions', type: :request do
       sign_in(user1)
     end
 
-    it 'denies access to recipe_suggestions#index' do
+    it "denies access to recipe_suggestions#index" do
       get inventory_recipe_suggestions_path(user2_inventory.id)
 
       expect(response).to_not be_successful

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -1,37 +1,37 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Recipes', type: :request do
+RSpec.describe "Recipes", type: :request do
   let!(:user) { create(:user) }
   let!(:recipe) { create(:recipe, user_id: user.id) }
 
-  describe 'Public access to recipes' do
-    describe 'GET /recipes/id' do
-      it 'permits access to recipes#show' do
+  describe "Public access to recipes" do
+    describe "GET /recipes/id" do
+      it "permits access to recipes#show" do
         get recipe_path(recipe)
         expect(response).to have_http_status(200)
       end
     end
 
-    describe 'GET /recipes' do
-      it 'denies access to recipes#index' do
+    describe "GET /recipes" do
+      it "denies access to recipes#index" do
         get recipes_path
         expect(response).to have_http_status(302)
       end
     end
 
-    it 'denies access to recipes#new' do
+    it "denies access to recipes#new" do
       get new_recipe_path
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to recipes#edit' do
+    it "denies access to recipes#edit" do
       get edit_recipe_path(recipe.id)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to recipes#create' do
+    it "denies access to recipes#create" do
       recipe_attributes = build(:recipe, user_id: user.id).attributes
 
       expect {
@@ -41,37 +41,37 @@ RSpec.describe 'Recipes', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to recipes#update' do
+    it "denies access to recipes#update" do
       patch recipe_path(recipe, recipe: recipe.attributes)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to recipes#destroy' do
+    it "denies access to recipes#destroy" do
       delete recipe_path(recipe)
       expect(response).to redirect_to new_user_session_path
     end
   end
 
-  describe 'Authenticated access to own recipes' do
+  describe "Authenticated access to own recipes" do
     before :each do
       sign_in user
     end
 
-    it 'renders recipes#show' do
+    it "renders recipes#show" do
       get recipe_path(recipe.id)
 
       expect(response).to be_successful
       expect(response).to have_http_status(200)
     end
 
-    it 'renders recipes#new' do
+    it "renders recipes#new" do
       get new_recipe_path
 
       expect(response).to be_successful
       expect(response).to render_template(:new)
     end
 
-    it 'renders recipes#edit' do
+    it "renders recipes#edit" do
       get edit_recipe_path(recipe.id)
 
       expect(response).to be_successful
@@ -79,7 +79,7 @@ RSpec.describe 'Recipes', type: :request do
       expect(response.body).to include(recipe.title)
     end
 
-    it 'renders recipes#create' do
+    it "renders recipes#create" do
       recipe_attributes = build(:recipe, user: user).attributes
 
       expect {
@@ -87,14 +87,14 @@ RSpec.describe 'Recipes', type: :request do
       }.to change(Recipe, :count)
     end
 
-    it 'renders recipes#update' do
-      new_title = 'completely different title'
-      patch recipe_path(recipe, recipe: { title: new_title })
+    it "renders recipes#update" do
+      new_title = "completely different title"
+      patch recipe_path(recipe, recipe: {title: new_title})
 
       expect(response).to redirect_to recipe_url(recipe)
     end
 
-    it 'renders recipes#destroy' do
+    it "renders recipes#destroy" do
       delete recipe_path(recipe)
 
       expect(response).to redirect_to recipes_url
@@ -112,29 +112,29 @@ RSpec.describe 'Recipes', type: :request do
       sign_in user
     end
 
-    it 'renders recipes#show' do
+    it "renders recipes#show" do
       get recipe_path(others_recipe.id)
 
       expect(response).to be_successful
       expect(response).to have_http_status(200)
     end
 
-    it 'denies access to recipes#edit' do
+    it "denies access to recipes#edit" do
       get edit_recipe_path(others_recipe.id)
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to recipes#update' do
-      new_title = 'completely different title'
-      patch recipe_path(others_recipe, recipe: { title: new_title })
+    it "denies access to recipes#update" do
+      new_title = "completely different title"
+      patch recipe_path(others_recipe, recipe: {title: new_title})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to recipes#destroy' do
+    it "denies access to recipes#destroy" do
       delete recipe_path(others_recipe)
 
       expect(response).to_not be_successful

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'ShoppingLists', type: :request do
-  describe 'Public access to shopping_lists' do
+RSpec.describe "ShoppingLists", type: :request do
+  describe "Public access to shopping_lists" do
     let(:user) { create(:user) }
     let(:user_shopping_list) { create(:shopping_list, user: user) }
 
@@ -11,35 +11,35 @@ RSpec.describe 'ShoppingLists', type: :request do
       user_shopping_list
     end
 
-    it 'denies access to shopping_lists#show' do
+    it "denies access to shopping_lists#show" do
       get shopping_list_path(user_shopping_list)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#index' do
+    it "denies access to shopping_lists#index" do
       get shopping_lists_path
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#new' do
+    it "denies access to shopping_lists#new" do
       get new_shopping_list_path
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#edit' do
+    it "denies access to shopping_lists#edit" do
       get edit_shopping_list_path(user_shopping_list.id)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#create' do
+    it "denies access to shopping_lists#create" do
       shopping_list_attributes = build(:shopping_list, user: user).attributes
 
       expect {
@@ -50,14 +50,14 @@ RSpec.describe 'ShoppingLists', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#update' do
+    it "denies access to shopping_lists#update" do
       patch shopping_list_path(user_shopping_list, shopping_list: user_shopping_list.attributes)
 
       expect(response).to have_http_status(302)
       expect(response).to redirect_to new_user_session_path
     end
 
-    it 'denies access to shopping_lists#destroy' do
+    it "denies access to shopping_lists#destroy" do
       delete shopping_list_path(user_shopping_list)
 
       expect(response).to have_http_status(302)
@@ -65,7 +65,7 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'Authenticated access to own shopping_lists' do
+  describe "Authenticated access to own shopping_lists" do
     let(:user) { create(:user) }
     let(:user_shopping_list_default) { create(:shopping_list, main: true, user: user) }
     let(:user_shopping_list) { create(:shopping_list, user: user) }
@@ -76,21 +76,21 @@ RSpec.describe 'ShoppingLists', type: :request do
       sign_in(user)
     end
 
-    it 'renders shopping_lists#show' do
+    it "renders shopping_lists#show" do
       get shopping_list_path(user_shopping_list)
 
       expect(response).to be_successful
       expect(response).to have_http_status(200)
     end
 
-    it 'renders shopping_lists#edit' do
+    it "renders shopping_lists#edit" do
       get edit_shopping_list_path(user_shopping_list.id)
 
       expect(response).to be_successful
       expect(response).to render_template(:edit)
     end
 
-    it 'renders shopping_lists#create' do
+    it "renders shopping_lists#create" do
       starting_count = ShoppingList.count
       shopping_list_attributes = build(:shopping_list, user: user).attributes
       post shopping_lists_path(shopping_list: shopping_list_attributes)
@@ -98,14 +98,14 @@ RSpec.describe 'ShoppingLists', type: :request do
       expect(ShoppingList.count).to eq(starting_count + 1)
     end
 
-    it 'renders shopping_lists#update' do
-      new_name = 'different name'
-      patch shopping_list_path(user_shopping_list, shopping_list: { name: new_name })
+    it "renders shopping_lists#update" do
+      new_name = "different name"
+      patch shopping_list_path(user_shopping_list, shopping_list: {name: new_name})
 
       expect(response).to redirect_to shopping_list_url(user_shopping_list)
     end
 
-    it 'renders shopping_lists#destroy' do
+    it "renders shopping_lists#destroy" do
       delete shopping_list_path(user_shopping_list)
 
       expect(response).to redirect_to(shopping_lists_url)
@@ -122,7 +122,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       sign_in(user1)
     end
 
-    it 'denies access to shopping_lists#show' do
+    it "denies access to shopping_lists#show" do
       get shopping_list_path(user2_shopping_list.id)
 
       expect(response).to_not be_successful
@@ -130,7 +130,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       expect(response).to redirect_to(root_url)
     end
 
-    it 'denies access to shopping_lists#edit' do
+    it "denies access to shopping_lists#edit" do
       get edit_shopping_list_path(user2_shopping_list.id)
 
       expect(response).to_not be_successful
@@ -138,15 +138,15 @@ RSpec.describe 'ShoppingLists', type: :request do
       expect(response).to redirect_to(root_url)
     end
 
-    it 'denies access to shopping_lists#update' do
-      new_name = 'completely different name'
-      patch shopping_list_path(user2_shopping_list, shopping_list: { name: new_name })
+    it "denies access to shopping_lists#update" do
+      new_name = "completely different name"
+      patch shopping_list_path(user2_shopping_list, shopping_list: {name: new_name})
 
       expect(response).to_not be_successful
       expect(response).to redirect_to root_url
     end
 
-    it 'denies access to shopping_lists#destroy' do
+    it "denies access to shopping_lists#destroy" do
       delete shopping_list_path(user2_shopping_list)
 
       expect(response).to_not be_successful

--- a/spec/routing/recipes_routing_spec.rb
+++ b/spec/routing/recipes_routing_spec.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe RecipesController, type: :routing do
-  describe 'routing' do
-    it 'routes to #index' do
-      expect(get: '/recipes').to route_to('recipes#index')
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/recipes").to route_to("recipes#index")
     end
 
-    it 'routes to #new' do
-      expect(get: '/recipes/new').to route_to('recipes#new')
+    it "routes to #new" do
+      expect(get: "/recipes/new").to route_to("recipes#new")
     end
 
-    it 'routes to #show' do
-      expect(get: '/recipes/1').to route_to('recipes#show', id: '1')
+    it "routes to #show" do
+      expect(get: "/recipes/1").to route_to("recipes#show", id: "1")
     end
 
-    it 'routes to #edit' do
-      expect(get: '/recipes/1/edit').to route_to('recipes#edit', id: '1')
+    it "routes to #edit" do
+      expect(get: "/recipes/1/edit").to route_to("recipes#edit", id: "1")
     end
 
-    it 'routes to #create' do
-      expect(post: '/recipes').to route_to('recipes#create')
+    it "routes to #create" do
+      expect(post: "/recipes").to route_to("recipes#create")
     end
 
-    it 'routes to #update via PUT' do
-      expect(put: '/recipes/1').to route_to('recipes#update', id: '1')
+    it "routes to #update via PUT" do
+      expect(put: "/recipes/1").to route_to("recipes#update", id: "1")
     end
 
-    it 'routes to #update via PATCH' do
-      expect(patch: '/recipes/1').to route_to('recipes#update', id: '1')
+    it "routes to #update via PATCH" do
+      expect(patch: "/recipes/1").to route_to("recipes#update", id: "1")
     end
 
-    it 'routes to #destroy' do
-      expect(delete: '/recipes/1').to route_to('recipes#destroy', id: '1')
+    it "routes to #destroy" do
+      expect(delete: "/recipes/1").to route_to("recipes#destroy", id: "1")
     end
   end
 end

--- a/spec/services/cronometer_parser_spec.rb
+++ b/spec/services/cronometer_parser_spec.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CronometerParser, type: :service do
   let(:parser) { CronometerParser.new(iframe_code) }
   let(:iframe_code) { valid_iframe_code }
-  let(:valid_iframe_code) { "<iframe title=\'CRONOMETER.com\' width=\'320\' height=\'540\' src=\'https://cronometer.com/facts.html?#{food_arg}&#{measure_arg}&labelType=AMERICAN\' frameborder=\'0\'></iframe>" }
-  let(:valid_food_arg) { 'food=12345678' }
-  let(:valid_measure_arg) { 'measure=87654321' }
+  let(:valid_iframe_code) { "<iframe title='CRONOMETER.com' width='320' height='540' src='https://cronometer.com/facts.html?#{food_arg}&#{measure_arg}&labelType=AMERICAN' frameborder='0'></iframe>" }
+  let(:valid_food_arg) { "food=12345678" }
+  let(:valid_measure_arg) { "measure=87654321" }
   let(:food_arg) { valid_food_arg }
   let(:measure_arg) { valid_measure_arg }
 
-  describe 'valid_iframe_data?' do
-    describe 'when the raw_iframe_code is nil' do
+  describe "valid_iframe_data?" do
+    describe "when the raw_iframe_code is nil" do
       let(:iframe_code) { nil }
-      it 'returns false' do
+      it "returns false" do
         expect(parser.valid_iframe_data?).to be(false)
       end
     end
 
-    describe 'when the raw_iframe_code is an empty string' do
-      let(:iframe_code) { '' }
-      it 'returns false' do
+    describe "when the raw_iframe_code is an empty string" do
+      let(:iframe_code) { "" }
+      it "returns false" do
         expect(parser.valid_iframe_data?).to be(false)
       end
     end
 
-    describe 'when the food_number is present and the measure_number is present' do
-      it 'returns true' do
-        allow(parser).to receive(:food_number).and_return('12345678')
-        allow(parser).to receive(:measure_number).and_return('87654321')
+    describe "when the food_number is present and the measure_number is present" do
+      it "returns true" do
+        allow(parser).to receive(:food_number).and_return("12345678")
+        allow(parser).to receive(:measure_number).and_return("87654321")
         expect(parser.valid_iframe_data?).to be(true)
       end
     end
 
-    describe 'when the food_number is present and the measure_number is NOT present' do
-      it 'returns true' do
-        allow(parser).to receive(:food_number).and_return('12345678')
+    describe "when the food_number is present and the measure_number is NOT present" do
+      it "returns true" do
+        allow(parser).to receive(:food_number).and_return("12345678")
         allow(parser).to receive(:measure_number).and_return(nil)
         expect(parser.valid_iframe_data?).to be(false)
       end
     end
 
-    describe 'when the food_number is NOT present and the measure_number is present' do
-      it 'returns true' do
+    describe "when the food_number is NOT present and the measure_number is present" do
+      it "returns true" do
         allow(parser).to receive(:food_number).and_return(nil)
-        allow(parser).to receive(:measure_number).and_return('87654321')
+        allow(parser).to receive(:measure_number).and_return("87654321")
         expect(parser.valid_iframe_data?).to be(false)
       end
     end
 
-    describe 'when the food_number is NOT present and the measure_number is NOT present' do
-      it 'returns true' do
+    describe "when the food_number is NOT present and the measure_number is NOT present" do
+      it "returns true" do
         allow(parser).to receive(:food_number).and_return(nil)
         allow(parser).to receive(:measure_number).and_return(nil)
         expect(parser.valid_iframe_data?).to be(false)
@@ -59,94 +59,94 @@ RSpec.describe CronometerParser, type: :service do
     end
   end
 
-  describe 'sanitized_iframe_src' do
-    describe 'when the required data is valid' do
-      it 'returns the expected url' do
+  describe "sanitized_iframe_src" do
+    describe "when the required data is valid" do
+      it "returns the expected url" do
         allow(parser).to receive(:valid_iframe_data?).and_return(true)
         expected_url = "https://cronometer.com/facts.html?food=12345678&measure=87654321&labelType=AMERICAN"
         expect(parser.sanitized_iframe_src).to eq(expected_url)
       end
     end
 
-    describe 'when the required data is not valid' do
-      it 'returns nil' do
+    describe "when the required data is not valid" do
+      it "returns nil" do
         allow(parser).to receive(:valid_iframe_data?).and_return(false)
         expect(parser.sanitized_iframe_src).to be(nil)
       end
     end
   end
 
-  describe 'private matching methods' do
-    let(:invalid_iframe_code) { 'oh hi there & good day&to you' }
+  describe "private matching methods" do
+    let(:invalid_iframe_code) { "oh hi there & good day&to you" }
 
-    describe 'private.food_number' do
-      describe 'when there is no food argument or data' do
-        let(:food_arg) { '' }
-        it 'returns nil' do
+    describe "private.food_number" do
+      describe "when there is no food argument or data" do
+        let(:food_arg) { "" }
+        it "returns nil" do
           expect(parser.send(:food_number)).to be(nil)
         end
       end
 
-      describe 'when the food arg is present, but there is no data' do
-        let(:food_arg) { 'food=' }
-        it 'returns nil' do
+      describe "when the food arg is present, but there is no data" do
+        let(:food_arg) { "food=" }
+        it "returns nil" do
           expect(parser.send(:food_number)).to be(nil)
         end
       end
 
-      describe 'when the food data is not a number' do
-        let(:food_arg) { 'food=foosbars' }
-        it 'returns nil' do
+      describe "when the food data is not a number" do
+        let(:food_arg) { "food=foosbars" }
+        it "returns nil" do
           expect(parser.send(:food_number)).to be(nil)
         end
       end
 
-      describe 'when the food data is a mix of numbers and characters' do
-        let(:food_arg) { 'food=f00sb44rs' }
-        it 'returns nil' do
+      describe "when the food data is a mix of numbers and characters" do
+        let(:food_arg) { "food=f00sb44rs" }
+        it "returns nil" do
           expect(parser.send(:food_number)).to be(nil)
         end
       end
 
-      describe 'when there is a match' do
-        it 'returns 12345678 as its value' do
-          expect(parser.send(:food_number)).to eq('12345678')
+      describe "when there is a match" do
+        it "returns 12345678 as its value" do
+          expect(parser.send(:food_number)).to eq("12345678")
         end
       end
     end
 
-    describe 'private.measure_number' do
-      describe 'when there is no measure argument or data' do
-        let(:measure_arg) { '' }
-        it 'returns nil' do
+    describe "private.measure_number" do
+      describe "when there is no measure argument or data" do
+        let(:measure_arg) { "" }
+        it "returns nil" do
           expect(parser.send(:measure_number)).to be(nil)
         end
       end
 
-      describe 'when the measure arg is present, but there is no data' do
-        let(:measure_arg) { 'measure=' }
-        it 'returns nil' do
+      describe "when the measure arg is present, but there is no data" do
+        let(:measure_arg) { "measure=" }
+        it "returns nil" do
           expect(parser.send(:measure_number)).to be(nil)
         end
       end
 
-      describe 'when the measure data is not a number' do
-        let(:measure_arg) { 'measure=foosbars' }
-        it 'returns nil' do
+      describe "when the measure data is not a number" do
+        let(:measure_arg) { "measure=foosbars" }
+        it "returns nil" do
           expect(parser.send(:measure_number)).to be(nil)
         end
       end
 
-      describe 'when the measure data is a mix of numbers and characters' do
-        let(:measure_arg) { 'measure=f00sb44rs' }
-        it 'returns nil' do
+      describe "when the measure data is a mix of numbers and characters" do
+        let(:measure_arg) { "measure=f00sb44rs" }
+        it "returns nil" do
           expect(parser.send(:measure_number)).to be(nil)
         end
       end
 
-      describe 'when there is a match' do
-        it 'returns 87654321 as its value' do
-          expect(parser.send(:measure_number)).to eq('87654321')
+      describe "when there is a match" do
+        it "returns 87654321 as its value" do
+          expect(parser.send(:measure_number)).to eq("87654321")
         end
       end
     end

--- a/spec/services/inventory_item_set_spec.rb
+++ b/spec/services/inventory_item_set_spec.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe InventoryItemSet, type: :service do
   let(:user) { create(:user) }
 
   before do
     recipe1 = create(:recipe, user: user)
-    create(:ingredient, recipe: recipe1, name: '1 cup water')
-    create(:ingredient, recipe: recipe1, name: '1 cup rice')
+    create(:ingredient, recipe: recipe1, name: "1 cup water")
+    create(:ingredient, recipe: recipe1, name: "1 cup rice")
 
     recipe2 = create(:recipe, user: user)
-    create(:ingredient, recipe: recipe2, name: '2 tablespoon water')
-    create(:ingredient, recipe: recipe2, name: '.5 cup beans')
+    create(:ingredient, recipe: recipe2, name: "2 tablespoon water")
+    create(:ingredient, recipe: recipe2, name: ".5 cup beans")
   end
 
-  describe '#suggest' do
-    it 'strips duplicates from the list' do
+  describe "#suggest" do
+    it "strips duplicates from the list" do
       items = "water\r\n\r\nrice\r\n\r\nwater\r\n\r\nwater"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
@@ -24,34 +24,34 @@ RSpec.describe InventoryItemSet, type: :service do
       expect(suggestions.keys).to eq(%w[water rice])
     end
 
-    xit 'can handle inventory items ending in s' do
-      items = 'waters'
+    xit "can handle inventory items ending in s" do
+      items = "waters"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
 
       expect(suggestions.keys).to eq(%w[water])
     end
 
-    it 'removes blanks from the list' do
+    it "removes blanks from the list" do
       items = "water\r\n\r\n   rice\r\n\r\nwater\r\n\r\nbeans  \r\n\r\n"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
 
-      expect(suggestions.keys).to_not include('')
+      expect(suggestions.keys).to_not include("")
       expect(suggestions.keys).to eq(%w[water rice beans])
     end
 
-    it 'returns each item with an array of recipes' do
+    it "returns each item with an array of recipes" do
       items = "water\r\n\r\nrice\r\n\r\nwater\r\n\r\nbeans"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
 
-      expect(suggestions['beans'].count).to eq(1)
-      expect(suggestions['rice'].count).to eq(1)
-      expect(suggestions['water'].count).to eq(2)
+      expect(suggestions["beans"].count).to eq(1)
+      expect(suggestions["rice"].count).to eq(1)
+      expect(suggestions["water"].count).to eq(2)
     end
 
-    it 'returns the list of items as keys' do
+    it "returns the list of items as keys" do
       items = "water\r\n\r\nrice\r\n\r\n"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
@@ -59,29 +59,29 @@ RSpec.describe InventoryItemSet, type: :service do
       expect(suggestions.keys).to eq(%w[water rice])
     end
 
-    it 'returns an [] for items without recipe matches' do
-      items = 'not an ingredient'
+    it "returns an [] for items without recipe matches" do
+      items = "not an ingredient"
       inventory = create(:inventory, user: user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
 
-      expect(suggestions['not an ingredient']).to eq([])
+      expect(suggestions["not an ingredient"]).to eq([])
     end
 
-    it 'only returns recipes for the given user' do
+    it "only returns recipes for the given user" do
       original_user = create(:user)
       recipe1 = create(:recipe, user: original_user)
-      create(:ingredient, recipe: recipe1, name: '1 cup rice')
+      create(:ingredient, recipe: recipe1, name: "1 cup rice")
 
       different_user = create(:user)
       recipe3 = create(:recipe, user: different_user)
-      create(:ingredient, recipe: recipe3, name: '.5 cup beans')
+      create(:ingredient, recipe: recipe3, name: ".5 cup beans")
 
       items = "beans\r\n\r\nrice"
       inventory = create(:inventory, user: original_user, items: items)
       suggestions = InventoryItemSet.new(inventory).suggest_recipes
 
-      expect(suggestions['rice'].count).to eq(1)
-      expect(suggestions['beans'].count).to eq(0)
+      expect(suggestions["rice"].count).to eq(1)
+      expect(suggestions["beans"].count).to eq(0)
     end
   end
 end

--- a/spec/services/user_data_setup_spec.rb
+++ b/spec/services/user_data_setup_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe UserDataSetup, type: :service do
   let(:user) { create(:user) }
 
-  describe 'self.setup' do
-    it 'populates default shopping_lists' do
+  describe "self.setup" do
+    it "populates default shopping_lists" do
       shopping_list_count_before = user.shopping_lists.count
       expect(shopping_list_count_before).to eq(0)
 
@@ -18,7 +18,7 @@ RSpec.describe UserDataSetup, type: :service do
       expect(user.shopping_lists.count).to be > 0
     end
 
-    it 'populates default aisles' do
+    it "populates default aisles" do
       aisle_count_before = user.aisles.count
       expect(aisle_count_before).to eq(0)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,8 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 
-require 'simplecov'
-SimpleCov.start 'rails' do
+require "simplecov"
+SimpleCov.start "rails" do
   enable_coverage :branch
 end
 
@@ -51,53 +51,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 Capybara.javascript_driver = :selenium_chrome_headless
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, {Silent: true}

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'shoulda-matchers'
+require "shoulda-matchers"
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/views/recipes/edit.html.erb_spec.rb
+++ b/spec/views/recipes/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe 'recipes/edit.html.erb', type: :view do
+RSpec.describe "recipes/edit.html.erb", type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/recipes/index.html.erb_spec.rb
+++ b/spec/views/recipes/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe 'recipes/index.html.erb', type: :view do
+RSpec.describe "recipes/index.html.erb", type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/recipes/new.html.erb_spec.rb
+++ b/spec/views/recipes/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe 'recipes/new.html.erb', type: :view do
+RSpec.describe "recipes/new.html.erb", type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/recipes/show.html.erb_spec.rb
+++ b/spec/views/recipes/show.html.erb_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe 'recipes/show.html.erb', type: :view do
+RSpec.describe "recipes/show.html.erb", type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/shopping_lists/show.html.erb_spec.rb
+++ b/spec/views/shopping_lists/show.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 # require 'rails_helper'
 
-RSpec.describe 'shopping_lists/show', type: :view do
+RSpec.describe "shopping_lists/show", type: :view do
   before(:each) do
     @user = create(:user)
     @shopping_list = create(:shopping_list, user_id: @user.id)
@@ -10,7 +10,7 @@ RSpec.describe 'shopping_lists/show', type: :view do
     render
   end
 
-  it 'displays basic shopping_list info' do
+  it "displays basic shopping_list info" do
     expect(rendered).to match(/Schedule an upcoming delivery/)
     expect(rendered).to match(/Shopping List Name 1/)
   end


### PR DESCRIPTION
## Problems Solved
* Takes a step towards using standardrb gem instead of rubocop gems
* Changes only spec files and spec configs
* Will allow more easy auto-formatting while using vs code
* These changes are mostly converting `'` to `"`
* A separate PR will update all app code with changes


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
