### PR TITLE
Remove simplecov

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -42,12 +42,6 @@ jobs:
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec
-      - name: SimpleCov Report
-        uses: aki77/simplecov-report-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failedThreshold: 0
-        if: always()
       - name: Check Seeds
         run: bundle exec rake db:seed
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,4 @@
 
 # Ignore Mac DS_Store files
 .DS_Store
-coverage/*
-!coverage/.keep
 .vscode

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ group :test do
   gem "launchy"                   # open browser with save_and_open_page
   gem "rails-controller-testing"  # allows for controller testing
   gem "shoulda-matchers"          # library for easier testing syntax
-  gem "simplecov"                 # using to display rspec coverage in PR comment
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,7 +574,6 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  simplecov
   spring
   spring-watcher-listen (~> 2.1.0)
   standard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,11 +14,6 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 
-require "simplecov"
-SimpleCov.start "rails" do
-  enable_coverage :branch
-end
-
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## Problems Solved
SimpleCov is flaky. I added it to this repo ( #826 , #810 ) to test it out on a simple project with a simple test suite before integrating it into a repo of a more complex project. I don't see value for it in this repo anymore, so it is not with fixing the flakiness. This PR simply removes the gem and any dependent files. 

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
