### PR TITLE
Auto run migrate on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: rails db:migrate


### PR DESCRIPTION
## Problems Solved
* removes overhead of needing to run `rake db:migrate` on the heroku server manually
* allows for this to be run automatically via instruction in the procfile

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
