### PR TITLE
Add created-at date to experimental recipes index

### DIFF
--- a/app/components/material_icon.rb
+++ b/app/components/material_icon.rb
@@ -21,6 +21,7 @@ class MaterialIcon
     when :checkmark then checkmark
     when :clock then clock
     when :copy then copy
+    when :convert then convert
     when :edit then edit_note
     when :event_repeat then event_repeat
     when :info then info
@@ -77,6 +78,12 @@ class MaterialIcon
     content_tag(:span, "done",
       class: symbol_classes,
       title: @title.presence || "Done")
+  end
+
+  def convert
+    content_tag(:span, "convert_to_text",
+      class: symbol_classes,
+      title: @title.presence || "Convert")
   end
 
   def copy

--- a/app/controllers/experimental_recipes_controller.rb
+++ b/app/controllers/experimental_recipes_controller.rb
@@ -4,7 +4,7 @@ class ExperimentalRecipesController < ApplicationController
   before_action :set_experimental_recipe, only: %i[edit update destroy]
 
   def index
-    @experimental_recipes = policy_scope(ExperimentalRecipe).by_title
+    @experimental_recipes = policy_scope(ExperimentalRecipe).order(created_at: :desc)
   end
 
   def new

--- a/app/views/experimental_recipes/index.html.erb
+++ b/app/views/experimental_recipes/index.html.erb
@@ -9,6 +9,7 @@
   <thead>
     <tr>
       <th colspan='2'>Recipe</th>
+      <th>Added</th>
       <th colspan='3'>Manage</th>
     </tr>
   </thead>
@@ -21,12 +22,13 @@
           </div>
         </td>
         <td><%= link_to recipe.title, recipe.source_url, target: '_blank' %></td>
+        <td><%= recipe.created_at.to_fs(:default) %></td>
         <td><%= link_to MaterialIcon.new(icon: :settings, size: :xlarge, title: 'Edit recipe').render, edit_experimental_recipe_path(recipe), 'aria-label': 'Edit recipe' %></td>
         <td>
           <%= link_to MaterialIcon.new(icon: :trash, size: :xlarge, title: 'Delete recipe').render,
                 recipe, method: :delete, 'aria-label': 'Delete recipe', data: { confirm: 'Are you sure? This action cannot be undone.' } %>
         </td>
-        <td><%= link_to 'convert to recipe', convert_from_experimental_path(experimental_recipe_id: recipe.id), method: :post %></td>
+        <td><%= link_to MaterialIcon.new(icon: :convert, size: :xlarge, title: 'Convert to recipe').render, convert_from_experimental_path(experimental_recipe_id: recipe.id), method: :post, 'aria-label': 'Convert to recipe' %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -8,3 +8,6 @@ Date::DATE_FORMATS[:short] = "%m/%d"
 
 # Sun 05/25 at 7:22 am
 Time::DATE_FORMATS[:timestamp] = "%a %m/%d at %l:%M %P"
+
+# 05-25-2020
+Time::DATE_FORMATS[:default] = "%m-%d-%Y"


### PR DESCRIPTION
## Problems Solved
I wanted a little more info on teh experimental recipes index. So i added the added-by date. To recoup some screen real estate, i changed the "convert" link to an icon. We'll see if I like it. 

## Screenshots
<img width="1474" height="1352" alt="Screenshot 2025-07-29 at 1 31 25 PM" src="https://github.com/user-attachments/assets/75fa65d5-38c7-47ea-bd24-8e5f32a3c7fa" />

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
