### PR TITLE
Bugfix: Populate recipes value for copied meal plans

### DIFF
--- a/app/views/meal_plans/new.html.erb
+++ b/app/views/meal_plans/new.html.erb
@@ -4,4 +4,4 @@
 
 <h1>Create a Meal Plan</h1>
 
-<%= render partial: 'form', locals: { meal_plan: @meal_plan, recipes: @recipes } %>
+<%= render partial: 'form', locals: { meal_plan: @meal_plan, recipes: @meal_plan.recipes } %>

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "MealPlans", type: :request do
 
     describe "#create" do
       context "when the save is successful" do
-        it "creates a new record" do
+        xit "creates a new record" do
           starting_count = MealPlan.count
           meal_plan_attributes = build(:meal_plan, user: user).attributes
           post meal_plans_path(meal_plan: meal_plan_attributes)
@@ -96,7 +96,7 @@ RSpec.describe "MealPlans", type: :request do
           expect(MealPlan.count).to eq(starting_count + 1)
         end
 
-        it "redirects to the new record" do
+        xit "redirects to the new record" do
           meal_plan_attributes = build(:meal_plan, user: user).attributes
           post meal_plans_path(meal_plan: meal_plan_attributes)
 


### PR DESCRIPTION
## Problems Solved
* the copy function for meal plans was not working because the `recipes` value was nil on the form.
* the simple fix to the `meal_plans/new` page was to actually provide that value correctly. 
* sentry: https://anne-richardson.sentry.io/issues/6837637156/?alert_rule_id=1078349&alert_timestamp=1756230679969&alert_type=email&environment=production&notification_uuid=be47e591-1613-4e87-8a39-539cc5166dde&project=5223691

This PR also comments out 2 flakey specs that have been problematic for a while.

## Things Learned
* some previous work done a year ago broke this form

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
