### PR TITLE
Add link to recipe source from edit page

### DIFF
--- a/app/components/material_icon.rb
+++ b/app/components/material_icon.rb
@@ -27,6 +27,7 @@ class MaterialIcon
     when :event_repeat then event_repeat
     when :info then info
     when :new then new_release
+    when :open_in_new then open_in_new
     when :plus_circle then plus_circle
     when :plus_square then plus_square
     when :quick_reference then quick_reference
@@ -127,6 +128,12 @@ class MaterialIcon
     content_tag(:span, "add_circle",
       class: symbol_classes,
       title: @title.presence || "Add")
+  end
+
+  def open_in_new
+    content_tag(:span, "open_in_new",
+      class: symbol_classes,
+      title: @title.presence || "Open")
   end
 
   def plus_square

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -28,7 +28,6 @@ module RecipesHelper
       content_tag(:span, "New!",
         class: "badge badge-warning ml-2 text-small font-weight-normal cursor-default",
         title: "New! Has not been made yet!") { icon + " New!" }
-      # MaterialIcon.new(icon: :new, classes: "text-warning cursor-default", title: "New! Has not been made yet").render
     elsif recipe.last_prepared < Time.zone.today.prev_month(4)
       MaterialIcon.new(icon: :calendar_clock, classes: "cursor-default", title: "It's been a while since this was last made").render
     else

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -21,10 +21,14 @@ module RecipesHelper
     elsif recipe.pending?
       icon = MaterialIcon.new(icon: :book, size: :small, title: "Pending").render
       content_tag(:span, "Pending",
-        class: "badge badge-secondary ml-2 text-small font-weight-normal cursor-default",
+        class: "badge badge-light ml-2 text-small font-weight-normal cursor-default",
         title: "Recipe has not been vetted or imported yet.") { icon + " Pending" }
     elsif recipe.last_prepared.nil? || first_time_is_this_week?(recipe)
-      MaterialIcon.new(icon: :new, classes: "text-warning cursor-default", title: "New! Has not been made yet").render
+      icon = MaterialIcon.new(icon: :new, size: :small, title: "New", classes: "cursor-default").render
+      content_tag(:span, "New!",
+        class: "badge badge-warning ml-2 text-small font-weight-normal cursor-default",
+        title: "New! Has not been made yet!") { icon + " New!" }
+      # MaterialIcon.new(icon: :new, classes: "text-warning cursor-default", title: "New! Has not been made yet").render
     elsif recipe.last_prepared < Time.zone.today.prev_month(4)
       MaterialIcon.new(icon: :calendar_clock, classes: "cursor-default", title: "It's been a while since this was last made").render
     else

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -131,6 +131,14 @@
 
       <div class="field">
         <%= form.label 'Original Instructions*', class: 'font-weight-bold mt-5' %>
+        <% if recipe.source_url.present? %>
+          <%= form.label class: 'font-weight-bold mt-5' do %>
+            <%= link_to recipe.source_url, target: '_blank' do %>
+              <%= MaterialIcon.new(icon: :open_in_new, title: "View source recipe").render %>
+            <% end %>
+          <% end %>
+        <% end %>
+
         <%= form.text_area :instructions, class: 'form-control instructions' %>
       </div>
     <% end %>


### PR DESCRIPTION
## Problems Solved
* adds target blank link from recipe edit page to make it easier to see the source if a source is present
* make badge for "pending" recipes less bold
* change the badge for a "new" recipe to be easier to see

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
