### PR TITLE
Display static tags on recipe show page

### DIFF
--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -44,7 +44,6 @@
   border-top: 1px solid gray;
   padding-top: .25rem;
   font-family: Function,'Trebuchet MS',Arial,sans-serif;
-  margin-bottom: 2rem;
   flex-wrap: wrap;
   column-gap: 1rem;
   justify-content: flex-start;

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, @recipe.title) %>
 
-<div class="row">
+<div class="row mb-4">
   <div class="col-12">
     <p><%= link_to MaterialIcon.new(icon: :arrow_left).render + "All Recipes", recipes_path %></p>
 
@@ -17,6 +17,11 @@
       <div>Total Time: <%= display_time(@recipe.total_time) %></div>
       <div>Reheat Time: <%= display_time(@recipe.reheat_time) %></div>
       <div>Prepared: <%= pluralize(@recipe.frequency, 'time') %></div>
+    </div>
+    <div>
+      <% @recipe.tags.each do |tag| %>
+        <span class="text-normal badge badge-pill badge-info"><%= tag.name %></span>
+      <% end %>
     </div>
   </div>
 </div><!-- row -->


### PR DESCRIPTION
## Related Issues & PRs
Closes #1071

## Problems Solved
* This allows recipe tags to be displayed on the recipe show page
* Currently, there is no UI way to add or remove tags from a recipe
* When there is a way, this will be in place to display them

## Screenshots
<img width="1482" height="796" alt="Screenshot 2025-10-15 at 2 04 43 PM" src="https://github.com/user-attachments/assets/451c79cc-dfca-40ee-8644-75583cd1e0a7" />
<img width="1518" height="700" alt="Screenshot 2025-10-15 at 2 04 57 PM" src="https://github.com/user-attachments/assets/95f74b4f-49e5-4f0a-950c-f9acd138e9f3" />


## Things Learned
* This was easy peasy
* Bootstrap has changed its pill badge syntax significantly between my version and the current version

## Due Diligence Checks
- [ ] ~If this work contains migrations, I have updated factories and seeds accordingly~
- [ ] ~I have written new specs for this work~
- [x] I have browser tested this work
- [ ] ~I have deployed the feature branch to production and browser tested it successfully~
