### PR TITLE
Fix missing partial bug

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -123,7 +123,7 @@
               <div class='form-check'>
                 <%= r.check_box class: 'form-check-input' %>
                 <%= r.label class: 'form-check-label' do %>
-                  <%= link_to r.object.name, r.object %>
+                  <%= r.object.name %>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/recipes/_recipes_table.html.erb
+++ b/app/views/recipes/_recipes_table.html.erb
@@ -18,7 +18,7 @@
         <td><%= recipe.last_prepared %></td>
         <td>
           <% if available_meal_plans_dropdown(current_user, recipe).any? %>
-            <%= render 'add_to_meal_plan_dropdown', meal_plan_recipe: MealPlanRecipe.new, recipe: recipe %></td>
+            <%= render 'recipes/add_to_meal_plan_dropdown', meal_plan_recipe: MealPlanRecipe.new, recipe: recipe %></td>
           <% end %>
         <td><%= link_to MaterialIcon.new(icon: :settings, title: 'Edit recipe').render, edit_recipe_path(recipe) %></td>
       </tr>

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "Editing: #{@recipe.title}") %>
+
 <p><%= link_to MaterialIcon.new(icon: :arrow_left).render + 'Back to Recipe', @recipe %></p>
 
 <h1>Editing <%= @recipe.title %></h1>


### PR DESCRIPTION
## Problems Solved
* Fixes bug where tags show page won't render if there are upcoming meal plans
* Lagniappe: 
  * also adds title to recipe edit page
  * removes weird link from tag name on recipe form

## Things Learned
* When I pulled the recipes table into a partial, I didn't look for partials _within_ that partial that may need an explicit file path. As it turns out, there was one and it caused this bug. So the lesson is to always look for partials within any file that I may be moving to another location or be using from another directory.

## Due Diligence Checks
- [ ] ~I have written new specs for this work~
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
