### PR TITLE
Handle share-style recipe urls

### DIFF
--- a/app/controllers/pending_recipes_controller.rb
+++ b/app/controllers/pending_recipes_controller.rb
@@ -12,7 +12,10 @@ class PendingRecipesController < ApplicationController
     @recipe = current_user.recipes.new(recipe_params)
     authorize(@recipe)
 
+    extracted_uri = URI.extract(@recipe.source_url)[0]
+    @recipe.source_url = extracted_uri if extracted_uri.present?
     @recipe.source_name = URI.parse(@recipe.source_url).host.gsub("www.", "")
+
     extracted_content = RecipeDataExtractor.extract_from_site(@recipe.source_url)
     @recipe = RecipeDataExtractor.format_data(recipe: @recipe, extracted_data: extracted_content)
 


### PR DESCRIPTION
## Related Issues & PRs
https://anne-richardson.sentry.io/issues/7010350404/?referrer=alert_email&alert_type=email&alert_timestamp=1762693989514&alert_rule_id=1078349&notification_uuid=6cd02840-6184-4543-9935-780e30ec709b&environment=production

## Problems Solved
When on mobile, often the easiest way to copy the site url is by using the share button on the url. Unfortunately, this also sometimes includes some extra text. For example, while intending to fill in just a URL in the recipe `source_url` field, I may be pasting content like `"5 Must-Try Soups for Fall & Winter Soup season is calling. https://share.fitonapp.com/html/invite-message/d79e287c34004d8885d31e7ea8d4621d"`. 
 
This causes the `URI` library's `.parse` to break. So to clean this up, we need to `URI.extract` and store that extracted string on the `@recipe` object instead.


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] ~I have written new specs for this work~
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
