### PR TITLE
Create measurement unit fallback for AI ingredient workflow

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -27,14 +27,17 @@ class Ingredient < ApplicationRecord
 
   STANDARD_UNITS = %w[
     4oz\ can
+    6oz\ can
     7oz\ can
     15oz\ can
     30oz\ can
+    as-needed
     box
     bulb
     bunch
     clove
     cup
+    dash
     dozen
     handful
     head
@@ -45,13 +48,17 @@ class Ingredient < ApplicationRecord
     loaf
     quart
     ounce
+    pinch
     pint
     slice
     sprig
     stalk
+    stem
     stick
+    strip
     tablespoon
     teaspoon
+    wedge
   ].freeze
 
   # Units that do not get pluralized

--- a/app/services/recipe_data_extractor.rb
+++ b/app/services/recipe_data_extractor.rb
@@ -81,10 +81,11 @@ class RecipeDataExtractor
         The data in the "ingredients" key should be stored as an array with each ingredient broken into its own hash with the following keys: "name", "quantity", "measurement_unit", and "preparation_style". 
         For example, an ingredient of "2 cloves of garlic, minced" would be represented as: 
         {"name": "garlic", "quantity": 2, "measurement_unit": "clove", "preparation_style": "minced"}.
-        If an ingredient does not have a quantity or measurement unit, skip that ingredient.
+        If an ingredient does not have a quantity or measurement unit, set the quantity to 1 and set the measurement_unit to "as-needed" for that ingredient.
         If an ingredient does not have a preparation_style, use a value of "" for that key.
         If an ingredient quantity has a fraction, convert it to a decimal number (e.g., 1 1/2 becomes 1.5).
         For measurement units, match to the following standard units where possible: #{Ingredient::UNITS.join(", ")}.
+        If the measurement_unit is not included in that list, use a value of "as-needed" for the measurement_unit.
 
         The instructions should be text with each step separated by 2 newline characters. 
         


### PR DESCRIPTION
## Problems Solved
Recipe ingredient lists are sometimes up to human discretion. This is a a little harder to handle when AI is parsing a recipe. Two problems arose in the ingredient parsing workflow and this PR improves upon both of those problems.
1. Sometimes the ingredient `measurement_unit` is not in the provided list. Ex: "6oz can"
2. Sometimes the `measurement_unit` and `quantity` are missing. Ex: "kosher salt, to-taste"

To handle these issues, I added some more measurement units and a fallback for the AI. Now, in the case where a `measurement_unit` and `quantity` are missing, instead of skipping the ingredient, the ingredient is set to `1 as-needed kosher salt, to-taste`. In the case where the `measurement_unit` is not in the list, the AI will insert `as-needed` in it's place. 

This works because a human still has to review the recipe before it is set to `active`. During review, the human can make those decisions about quantities and units. 

## Due Diligence Checks
- [ ] ~If this work contains migrations, I have updated factories and seeds accordingly~
- [ ] ~I have written new specs for this work~ the logic is in the prompt and can't be mocked in a useful way
- [x] I have browser tested this work
- [ ] ~I have deployed the feature branch to production and browser tested it successfully~ Not required
