### PR TITLE
Toggle strikethrough for individual recipe instructions

### DIFF
--- a/app/assets/stylesheets/tailwind_styles.scss
+++ b/app/assets/stylesheets/tailwind_styles.scss
@@ -9,3 +9,9 @@
 // flex-direction
 .flex-col{ flex-direction: column; }
 .flex-row { flex-direction: row; }  
+
+// text-decoration
+.line-through {text-decoration-line: line-through;}
+
+// cursor
+.cursor-pointer {cursor: pointer;}

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -52,7 +52,7 @@
     <div class='row'>
       <div class='col-sm-12'>
         <h3>Instructions</h3>
-        <div class="card mb-5">
+        <div id="js-instructions" class="card mb-5">
           <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs">
               <li class="nav-item">
@@ -109,3 +109,16 @@
     <%= render partial: 'nutritional_information', locals: { recipe: @recipe, iframe_parser: CronometerParser.new(@recipe.nutrition_data_iframe) } %>
   </div>
 </div> <!-- row -->
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const instructionItems = document.querySelectorAll("#js-instructions .tab-content ol li");
+
+    instructionItems.forEach(line => {
+      line.classList.add('cursor-pointer');
+      line.addEventListener('click', function() {
+        this.classList.toggle('line-through');
+      });
+     });
+  });
+</script>


### PR DESCRIPTION
## Problems Solved
* When doing meal prep with 2 people and multiple steps per recipe, it can be confusing to remember which step you are on. 
* This PR adds the ability to toggle a strikethrough on any individual step of a recipe.

## Screenshots
<img width="763" height="397" alt="Screenshot 2025-12-11 at 11 11 37 AM" src="https://github.com/user-attachments/assets/49aa7725-ce20-40a9-b881-e40d6cb7807b" />


## Things Learned
* I had forgotten how to javascript XD

## Due Diligence Checks
- [x] ~If this work contains migrations, I have updated factories and seeds accordingly~
- [x] ~I have written new specs for this work~
- [x] I have browser tested this work
- [ ] ~I have deployed the feature branch to production and browser tested it successfully~
