### PR TITLE
Modernize view rendering patterns (section 6.3)

### DIFF
--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |type, message| %>
   <div class="mt-3 alert alert-<%= bootstrap_flash_class(type) %> alert-dismissible fadein">
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    <%= message.html_safe %>
+    <%= sanitize(message) %>
   </div>
 <% end %>

--- a/app/views/shopping_list_items/_active_items.html.erb
+++ b/app/views/shopping_list_items/_active_items.html.erb
@@ -3,9 +3,7 @@
     <% if aisle %>
       <%= tag.div id: dom_id(aisle) do %>
         <h4 class='aisle'><%= aisle.name %></h4>
-        <% items.each do |item| %>
-          <%= render partial: '/shopping_list_items/item', locals: { item: item } %>
-        <% end %><!-- each -->
+        <%= render partial: '/shopping_list_items/item', collection: items, as: :item %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -29,7 +29,5 @@
 
 <h4 class='aisle'>Crossed Off</h4>
 <section id='js-inactive-items' class='inactive-items'>
-  <% @shopping_list.shopping_list_items.includes(:list).inactive.by_recently_edited.limit(30).each do |item| %>
-    <%= render partial: '/shopping_list_items/item', locals: { item: item } %>
-  <% end %>
+  <%= render partial: '/shopping_list_items/item', collection: @shopping_list.shopping_list_items.includes(:list).inactive.by_recently_edited.limit(30), as: :item %>
 </section>


### PR DESCRIPTION
## Summary

Addresses view modernization tasks from #1214, section 6.3:

- **Collection rendering:** Replaced manual `.each` + `render partial:` loops with `render partial:, collection:` syntax in `shopping_list_items/_active_items.html.erb` and `shopping_lists/show.html.erb`
- **XSS fix:** Replaced `message.html_safe` with `sanitize(message)` in `shared/_flashes.html.erb` to safely handle flash messages containing user-provided content (e.g. shopping list names) while still allowing intentional HTML markup to render

## Things Learned
* you can skip the loop by rendering a partial with the `collection` arg like `<%= render partial: '/shopping_list_items/item', collection: items, as: :item %>`
* `sanitize` accepts a `tags:` option: `sanitize(message, tags: %w[strong a])`

## Test plan

- [x] Verify shopping list active items render correctly by aisle
- [x] Verify crossed-off items render correctly on shopping list show page
- [x] Verify flash messages display correctly (success, error, warning, alert)
- [x] Verify a flash message containing a shopping list name renders safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)