### PR TITLE
Dynamically add ingredient fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,13 @@ Located in `lib/tasks/`:
 ## Solid Trio Implementation
 The Solid Trio (`solid_cache`, `solid_cable`, `solid_queue`) are implemented as tables in the main database instead of separate tables. https://guides.rubyonrails.org/8_0_release_notes.html
 
-## Styling & Assets
+## Code Style & Project Conventions
 
 **Ruby/Rails:**
 - Use Rails helpers when available and appropriate. For example, use `<%= turbo_frame_tag dom_id(@item) %>` instead of `<turbo-frame id="foo">`
+
+**RSpec:**
+- Use a `before` block instead of a `let!`. Ex: use `before { user }` instead of `let!(:user) { create(:user) }` 
 
 **CSS Architecture:**
 - All styles use plain CSS (no SASS/SCSS preprocessor)

--- a/app/components/material_icon.rb
+++ b/app/components/material_icon.rb
@@ -22,6 +22,7 @@ class MaterialIcon
     when :book then book
     when :checkmark then checkmark
     when :clock then clock
+    when :close then close
     when :copy then copy
     when :convert then convert
     when :edit then edit_note
@@ -94,6 +95,13 @@ class MaterialIcon
       class: symbol_classes,
       alt: @title.presence || "Duration warning",
       title: @title.presence || "Duration warning")
+  end
+
+  def close
+    content_tag(:span, "close",
+      class: symbol_classes,
+      alt: @title.presence || "Close",
+      title: @title.presence || "Close")
   end
 
   def checkmark

--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class IngredientsController < ApplicationController
+  def new
+    @recipe = Recipe.find(params[:recipe_id])
+  end
+
+  private
+
+  def ingredient_params
+    params.require(:ingredient).permit(:recipe_id, :quantity, :measurement_unit, :name, :preparation_style)
+  end
+end

--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -2,7 +2,6 @@
 
 class IngredientsController < ApplicationController
   def new
-    @recipe = Recipe.find(params[:recipe_id])
   end
 
   private

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -38,9 +38,6 @@ class RecipesController < ApplicationController
 
   def edit
     authorize(@recipe)
-
-    ingredient_qty = @recipe.ingredients.any? ? 3 : 15
-    ingredient_qty.times { @recipe.ingredients.build(quantity: nil) }
   end
 
   def update

--- a/app/javascript/controllers/remove_form_field_controller.js
+++ b/app/javascript/controllers/remove_form_field_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  remove(event) {                                                                                                                                                   
+    event.preventDefault()
+    this.element.closest(".row").remove()
+  }                                                                                                                                                                 
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="mb-3">
-    <%= f.label :email, class: 'font-weight-bold' %><br>
+    <%= f.label :email, class: 'fw-bold' %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
@@ -14,7 +14,7 @@
   <% end %>
 
   <div class="field mt-4">
-    <%= f.label 'New Password', class: 'font-weight-bold' %> <i class='text-muted'>(leave blank if you don't want to change it)</i><br>
+    <%= f.label 'New Password', class: 'fw-bold' %> <i class='text-muted'>(leave blank if you don't want to change it)</i><br>
     <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
     <% if @minimum_password_length %>
       <em class='form-text text-muted'><%= @minimum_password_length %> characters minimum</em>
@@ -22,12 +22,12 @@
   </div>
 
   <div class="field mt-4">
-    <%= f.label 'Confirm New Password', class: 'font-weight-bold' %><br>
+    <%= f.label 'Confirm New Password', class: 'fw-bold' %><br>
     <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="field mt-4">
-    <%= f.label :current_password, class: 'font-weight-bold' %> <i class='text-muted'>(we need your current password to confirm your changes)</i><br>
+    <%= f.label :current_password, class: 'fw-bold' %> <i class='text-muted'>(we need your current password to confirm your changes)</i><br>
     <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 

--- a/app/views/ingredients/_form_fields.html.erb
+++ b/app/views/ingredients/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="row border-bottom mb-0">
-  <div class="col-2 p-2 fw-bolder"><%= f_ingredient.number_field :quantity, class: 'form-control', step: 'any' %></div>
+  <div class="col-2 p-2"><%= f_ingredient.number_field :quantity, class: 'form-control', step: 'any' %></div>
   <div class="col-2 p-2">
     <%= f_ingredient.select :measurement_unit,
       options_for_select(Ingredient::UNITS, selected: f_ingredient.object.measurement_unit),
@@ -8,5 +8,12 @@
   </div>
   <div class="col-4 p-2"><%= f_ingredient.text_field :name, class: 'form-control' %></div>
   <div class="col-3 p-2"><%= f_ingredient.text_field :preparation_style, class: 'form-control' %></div>
-  <div class="col-1 p-2"><%= f_ingredient.check_box :_destroy, class: 'form-check-input' if f_ingredient.object.persisted? %></div>
+  <div class="col-1 p-2">
+    <% if f_ingredient.object.persisted? %>
+      <%= f_ingredient.check_box :_destroy, class: 'form-check-input' %>
+    <% else %>
+      <%= link_to MaterialIcon.new(icon: :close).render.html_safe, "#",
+          data: { controller: "remove-form-field", action: "click->remove-form-field#remove" } %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/ingredients/_form_fields.html.erb
+++ b/app/views/ingredients/_form_fields.html.erb
@@ -1,14 +1,12 @@
-<td class='py-2'><%= f_ingredient.number_field :quantity, class: 'form-control', step: 'any' %></td>
-
-<td class='py-2'>
-  <%= f_ingredient.select :measurement_unit,
-        options_for_select(Ingredient::UNITS, selected: f_ingredient.object.measurement_unit),
-        {include_blank: true},
-        class: 'form-control' %>
-</td>
-
-<td class='py-2'><%= f_ingredient.text_field :name, class: 'form-control' %></td>
-
-<td class='py-2'><%= f_ingredient.text_field :preparation_style, class: 'form-control' %></td>
-
-<td class='py-2'><%= f_ingredient.check_box :_destroy if f_ingredient.object.persisted? %></td>
+<div class="row border-bottom mb-0">
+  <div class="col-2 p-2 fw-bolder"><%= f_ingredient.number_field :quantity, class: 'form-control', step: 'any' %></div>
+  <div class="col-2 p-2">
+    <%= f_ingredient.select :measurement_unit,
+      options_for_select(Ingredient::UNITS, selected: f_ingredient.object.measurement_unit),
+      {include_blank: true},
+      class: 'form-control' %>
+  </div>
+  <div class="col-4 p-2"><%= f_ingredient.text_field :name, class: 'form-control' %></div>
+  <div class="col-3 p-2"><%= f_ingredient.text_field :preparation_style, class: 'form-control' %></div>
+  <div class="col-1 p-2"><%= f_ingredient.check_box :_destroy, class: 'form-check-input' if f_ingredient.object.persisted? %></div>
+</div>

--- a/app/views/ingredients/new.turbo_stream.erb
+++ b/app/views/ingredients/new.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.append 'js_ingredients_table' do %>
+  <%= fields_for 'recipe[ingredients_attributes][]', Ingredient.new, index: Time.current.to_i do |f_ingredient| %>
+    <%= render partial: '/ingredients/form_fields', locals: { f_ingredient: f_ingredient } %>
+  <% end %>
+<% end %>

--- a/app/views/pending_recipes/new.html.erb
+++ b/app/views/pending_recipes/new.html.erb
@@ -48,7 +48,7 @@
     <% if current_user.tags.present? %>
         <div class="row mt-3">
           <div class="col-sm-3">
-            <%= form.label 'Select Tags', class: 'font-weight-bold' %>
+            <%= form.label 'Select Tags', class: 'fw-bold' %>
           </div>
           <div class="col-sm-9">
             <%= form.collection_check_boxes :tag_ids, current_user.tags, :id, :name do |r| %>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div> <!-- row -->
 
-    <div class="row">
+    <div class="row mb-3">
       <div class="field col-sm">
         <%= form.label :source_name, class: 'fw-bold' %>
         <%= form.text_field :source_name, class: 'form-control' %>
@@ -28,7 +28,7 @@
       <%= form.text_field :image_url, class: 'form-control' %>
     </div>
 
-    <div class="row">
+    <div class="row mb-3">
       <div class="field col-sm">
         <%= form.label :servings, class: 'fw-bold' %>
         <%= form.number_field :servings, class: 'form-control' %>
@@ -98,12 +98,13 @@
         <div class="col-1 py-1 px-2"><%= MaterialIcon.new(icon: :trash, size: :large).render %></div>
       </div>
       <%= form.fields_for :ingredients do |f_ingredient| %>
-        <%= render 'ingredients/form_fields', f_ingredient: f_ingredient %>
+        <%= render partial: '/ingredients/form_fields', locals: { f_ingredient: f_ingredient } %>
       <% end %>
     </div>
+    <%= link_to "Add ingredient", new_ingredient_path(recipe_id: recipe), class: "mt-2 #{button_classes}", data: {turbo_stream: true} %>
 
     <% if tags.present? %>
-      <div class="row mt-3">
+      <div class="row mt-4">
         <div class="col-sm-3">
           <%= form.label 'Select Tags', class: 'fw-bold' %>
         </div>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -89,25 +89,17 @@
     </div> <!-- row -->
 
     <%= form.label 'Ingredients*', class: 'font-weight-bold mt-5' %>
-    <div class="ingredients-container w-100 overflow-x-scroll">
-      <table>
-        <thead>
-          <tr class='border-bottom'>
-            <th class='w-10 mw-5'>Qty</th>
-            <th class='w-10 mw-6'>Unit</th>
-            <th class='w-20 mw-15'>Name</th>
-            <th class='w-20 mw-15'>Preparation Style</th>
-            <th class='w-5 mw-1'><%= MaterialIcon.new(icon: :trash, size: :large).render %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= form.fields_for :ingredients do |f_ingredient| %>
-            <tr class='border-bottom'>
-              <%= render 'ingredients/form_fields', f_ingredient: f_ingredient %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+    <div id="js_ingredients_table" class="container ingredients-container w-100 overflow-x-scroll">
+      <div class=" row fw-bolder border-bottom border-top mb-0 text-bg-light ">
+        <div class="col-2 py-1 px-2">Qty</div>
+        <div class="col-2 py-1 px-2">Unit</div>
+        <div class="col-4 py-1 px-2">Name</div>
+        <div class="col-3 py-1 px-2">Preparation Style</div>
+        <div class="col-1 py-1 px-2"><%= MaterialIcon.new(icon: :trash, size: :large).render %></div>
+      </div>
+      <%= form.fields_for :ingredients do |f_ingredient| %>
+        <%= render 'ingredients/form_fields', f_ingredient: f_ingredient %>
+      <% end %>
     </div>
 
     <% if tags.present? %>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col">
         <div class="mb-3">
-          <%= form.label "Title*" %>
+          <%= form.label "Title*", class: 'fw-bold' %>
           <%= form.text_field :title, autofocus: true, class: 'form-control' %>
         </div>
       </div>
@@ -13,39 +13,39 @@
 
     <div class="row">
       <div class="field col-sm">
-        <%= form.label :source_name %>
+        <%= form.label :source_name, class: 'fw-bold' %>
         <%= form.text_field :source_name, class: 'form-control' %>
       </div>
 
       <div class="field col-sm">
-        <%= form.label "Source URL*" %>
+        <%= form.label "Source URL*", class: 'fw-bold' %>
         <%= form.text_field :source_url, class: 'form-control' %>
       </div>
     </div>
 
     <div class="mb-3">
-      <%= form.label :image_url %>
+      <%= form.label :image_url, class: 'fw-bold' %>
       <%= form.text_field :image_url, class: 'form-control' %>
     </div>
 
     <div class="row">
       <div class="field col-sm">
-        <%= form.label :servings %>
+        <%= form.label :servings, class: 'fw-bold' %>
         <%= form.number_field :servings, class: 'form-control' %>
       </div>
 
       <div class="field col-sm">
-        <%= form.label 'Prep Time (min)' %>
+        <%= form.label 'Prep Time (min)', class: 'fw-bold' %>
         <%= form.number_field :prep_time, class: 'form-control' %>
       </div>
 
       <div class="field col-sm">
-        <%= form.label 'Cook Time (min)' %>
+        <%= form.label 'Cook Time (min)', class: 'fw-bold' %>
         <%= form.number_field :cook_time, class: 'form-control' %>
       </div>
 
       <div class="field col-sm">
-        <%= form.label 'Reheat Time (min)' %>
+        <%= form.label 'Reheat Time (min)', class: 'fw-bold' %>
         <%= form.number_field :reheat_time, class: 'form-control' %>
       </div>
     </div>
@@ -53,7 +53,7 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="mb-3">
-          <%= form.label :extra_work_note %>
+          <%= form.label :extra_work_note, class: 'fw-bold' %>
           <%= form.text_field :extra_work_note, class: 'form-control' %>
         </div>
       </div>
@@ -62,7 +62,7 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="mb-3">
-          <%= form.label 'Cronometer iframe' %>
+          <%= form.label 'Cronometer iframe', class: 'fw-bold' %>
           <%= form.text_area :nutrition_data_iframe, class: 'form-control' %>
         </div>
       </div>
@@ -71,14 +71,14 @@
     <div class="row">
       <div class="col-sm-10">
         <div class="mb-3">
-          <%= form.label :notes %>
+          <%= form.label :notes, class: 'fw-bold' %>
           <%= form.text_area :notes, class: 'form-control' %>
         </div>
       </div>
       <% if form.object.persisted? %>
         <div class="col-sm-2">
           <div class="mb-3">
-            <%= form.label :status %>
+            <%= form.label :status, class: 'fw-bold' %>
             <%= form.select :status,
                             Recipe.statuses.keys.map { |s| [s.titleize, s] },
                             {},
@@ -88,7 +88,7 @@
       <% end %>
     </div> <!-- row -->
 
-    <%= form.label 'Ingredients*', class: 'font-weight-bold mt-5' %>
+    <%= form.label 'Ingredients*', class: 'fw-bold mt-5' %>
     <div id="js_ingredients_table" class="container ingredients-container w-100 overflow-x-scroll">
       <div class=" row fw-bolder border-bottom border-top mb-0 text-bg-light ">
         <div class="col-2 py-1 px-2">Qty</div>
@@ -105,7 +105,7 @@
     <% if tags.present? %>
       <div class="row mt-3">
         <div class="col-sm-3">
-          <%= form.label 'Select Tags', class: 'font-weight-bold' %>
+          <%= form.label 'Select Tags', class: 'fw-bold' %>
         </div>
         <div class="col-sm-9">
           <%= form.collection_check_boxes :tag_ids, tags, :id, :name do |r| %>
@@ -123,23 +123,23 @@
     <div class="row">
       <div class="col-lg-6 col-md-12">
         <div class="mb-3">
-          <%= form.label 'Prep Day Instructions', class: 'font-weight-bold mt-5' %>
+          <%= form.label 'Prep Day Instructions', class: 'fw-bold mt-3' %>
           <%= form.text_area :prep_day_instructions, class: 'form-control instructions' %>
         </div>
       </div>
 
       <div class="col-lg-6 col-md-12">
         <div class="mb-3">
-          <%= form.label :reheat_instructions, class: 'font-weight-bold mt-5' %>
+          <%= form.label :reheat_instructions, class: 'fw-bold mt-3' %>
           <%= form.text_area :reheat_instructions, class: 'form-control instructions' %>
         </div>
       </div>
     </div><!-- row -->
 
     <div class="mb-3">
-      <%= form.label 'Original Instructions*', class: 'font-weight-bold mt-5' %>
+      <%= form.label 'Original Instructions*', class: 'fw-bold mt-3' %>
       <% if recipe.source_url.present? %>
-        <%= form.label class: 'font-weight-bold mt-5' do %>
+        <%= form.label class: 'fw-bold mt-5' do %>
           <%= link_to recipe.source_url, target: '_blank' do %>
             <%= MaterialIcon.new(icon: :open_in_new, title: "View source recipe").render %>
           <% end %>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -101,7 +101,10 @@
         <%= render partial: '/ingredients/form_fields', locals: { f_ingredient: f_ingredient } %>
       <% end %>
     </div>
-    <%= link_to "Add ingredient", new_ingredient_path(recipe_id: recipe), class: "mt-2 #{button_classes}", data: {turbo_stream: true} %>
+
+    <%= link_to new_ingredient_path, class: button_classes("warning float-end mt-2"), data: { turbo_stream: true } do %>
+      <%= MaterialIcon.new(icon: :plus_circle, title: 'Add ingredient').render %>  Add ingredient
+    <% end %>
 
     <% if tags.present? %>
       <div class="row mt-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,9 @@ Rails.application.routes.draw do
   resources :pending_recipes, only: [:new, :create]
   resources :meal_plan_recipes, only: [:create]
 
+  resources :ingredients, only: [:new]
   resources :recipes, only: [:show, :index, :new, :create, :edit, :update, :destroy] do
     member do
-      resources :ingredients, only: [:new]
       post :copy_for_user
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
   resources :recipes, only: [:show, :index, :new, :create, :edit, :update, :destroy] do
     member do
+      resources :ingredients, only: [:new]
       post :copy_for_user
     end
   end

--- a/spec/requests/ingredients_spec.rb
+++ b/spec/requests/ingredients_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Ingredients", type: :request do
+  let(:user) { create(:user) }
+
+  before { user }
+
+  describe "GET /ingredients/new" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get new_ingredient_path, headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "returns a turbo stream response" do
+        get new_ingredient_path, headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        expect(response).to be_successful
+        expect(response.media_type).to eq "text/vnd.turbo-stream.html"
+      end
+
+      it "renders the new template" do
+        get new_ingredient_path, headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
Closes #1266 
Wrote a blog post about it here: https://lortza.github.io/2026/04/13/child-fields-in-nested-forms.html

## This PR Does
* allows the user to add new ingredient fields to the form dynamically
* provides a stimulus option to remove the field 
* updates a deprecated Bootstrap font weight class name


## Screenshots
Add and remove recipe field dynamically
![feature](https://github.com/user-attachments/assets/cd297dda-48a9-446d-9228-c5bf38df2760)

It works!
![new_ingredient](https://github.com/user-attachments/assets/73db57ed-b17d-4151-a871-f06d45dd7950)

## Things Learned
* adding form fields to a nested form is a little tricky because we don't have access to the form object in the controller
* although an `ingredient` belongs to a `recipe`, the recipe instance is not needed when building ingredient form fields for the recipe.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I updated the README with new/changed features
- [x] I updated `CLAUDE.md` with crucial working details
- [x] I have written new specs for this work
- [x] I have browser tested this work locally
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
