### PR TITLE
Add tags dynamically on recipe form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,8 @@ gem "pundit"                    # Authorization
 gem "sentry-rails"              # Rails support for Sentry
 gem "sentry-ruby"               # Error reporting to Sentry.io
 
-# Web scraping
+# HTTP Requests & Web scraping
+gem "requestjs-rails"           # JS library for making HTTP requests in Stimulus. https://github.com/rails/requestjs-rails
 gem "httparty"                  # Makes HTTP requests easier
 gem "nokogiri", ">= 1.8.5"      # HTML, XML, SAX, and Reader parser. Loofah depends on Nokogiri.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    requestjs-rails (0.0.14)
+      railties (>= 7.1.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -687,6 +689,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   reek
+  requestjs-rails
   rspec-rails
   rubocop-rails-omakase
   rubycritic
@@ -882,6 +885,7 @@ CHECKSUMS
   reek (6.5.0) sha256=d26d3a492773b2bbc228888067a21afe33ac07954a17dbd64cdeae42c4c69be1
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  requestjs-rails (0.0.14) sha256=bb494198993b9bf136adeeffa3594c0143c7d16c7de4485c5e20d9c126e69a2d
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Live on heroku as [myfoodplanner](http://myfoodplanner.herokuapp.com)
 - Notes
   - Separate notes section to keep your favorite conversions or other things you may need to jot down that aren't related to one specific recipe.
   - Mark a note as "favorite" for it to appear in the Notes dropdown.
-
+- Tags
+  - Add tags to recipes easily without leaving the recipe form
+  - Filter recipe index page by tag
 
 ## Getting Started
 - Fork & Clone

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -17,9 +17,15 @@ class TagsController < ApplicationController
     authorize(@tag)
 
     if @tag.save
-      redirect_to tags_url
+      respond_to do |format|
+        format.html { redirect_to tags_url }
+        format.turbo_stream
+      end
     else
-      render :new
+      respond_to do |format|
+        format.html { render :new, status: :unprocessable_entity }
+        format.turbo_stream { render status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "@rails/request.js"
 
 // External libraries
 import "bootstrap"

--- a/app/javascript/controllers/inline_tag_creator_controller.js
+++ b/app/javascript/controllers/inline_tag_creator_controller.js
@@ -15,9 +15,5 @@ export default class extends Controller {
       body: { tag: { name } },
       responseKind: "turbo-stream"
     })
-
-    if (response.ok) {
-      this.inputTarget.value = ""
-    }
   }
 }

--- a/app/javascript/controllers/inline_tag_creator_controller.js
+++ b/app/javascript/controllers/inline_tag_creator_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+import { post } from "@rails/request.js"
+
+export default class extends Controller {
+  static targets = ["input"]
+  static values = { url: String }
+
+  async createTag(event) {
+    event.preventDefault()
+
+    const name = this.inputTarget.value.trim()
+    if (!name) return
+
+    const response = await post(this.urlValue, {
+      body: { tag: { name } },
+      responseKind: "turbo-stream"
+    })
+
+    if (response.ok) {
+      this.inputTarget.value = ""
+    }
+  }
+}

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -113,36 +113,34 @@
       <% end %>
     </div>
 
-    <% if tags.present? %>
-      <%= tag.div(data: {controller: "inline-tag-creator", inline_tag_creator_url_value: tags_path}, class: "row mt-4" ) do %>
-        <div class="col-sm-3">
-          <p class="fw-bold mb-1">Select Tags</p>
-          <div class="field">
-            <%= tag.input(type: "text",
-                id: "new_tag_name",
-                placeholder: "new tag",
-                class: "form-control",
-                data: { inline_tag_creator_target: "input", action: "keydown.enter->inline-tag-creator#createTag" },
-                autocomplete: "off") %>
-            <div id="inline-tag-error" class="text-danger small mt-1"></div>
-          </div>
-          <%= tag.button(type: "button", data: { action: "click->inline-tag-creator#createTag" }, class: "#{button_classes} mt-2") do %>
-            Add Tag
+    <%= tag.div(data: {controller: "inline-tag-creator", inline_tag_creator_url_value: tags_path}, class: "row mt-4" ) do %>
+      <div class="col-sm-3">
+        <p class="fw-bold mb-1">Select Tags</p>
+        <div class="field">
+          <%= tag.input(type: "text",
+              id: "new_tag_name",
+              placeholder: "new tag",
+              class: "form-control",
+              data: { inline_tag_creator_target: "input", action: "keydown.enter->inline-tag-creator#createTag" },
+              autocomplete: "off") %>
+          <div id="js_inline_tag_error" class="text-danger small mt-1"></div>
+        </div>
+        <%= tag.button(type: "button", data: { action: "click->inline-tag-creator#createTag" }, class: "#{button_classes} mt-2") do %>
+          Add Tag
+        <% end %>
+      </div>
+      <div class="col-sm-9">
+        <div id="js_recipe_tags_list">
+          <%= form.collection_check_boxes :tag_ids, tags, :id, :name do |r| %>
+            <div class="form-check">
+              <%= r.check_box class: 'form-check-input' %>
+              <%= r.label class: 'form-check-label' do %>
+                <%= r.object.name %>
+              <% end %>
+            </div>
           <% end %>
         </div>
-        <div class="col-sm-9">
-          <div id="js_recipe_tags_list">
-            <%= form.collection_check_boxes :tag_ids, tags, :id, :name do |r| %>
-              <div class="form-check">
-                <%= r.check_box class: 'form-check-input' %>
-                <%= r.label class: 'form-check-label' do %>
-                  <%= r.object.name %>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
+      </div>
     <% end %>
 
     <div class="row">

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -114,21 +114,35 @@
     </div>
 
     <% if tags.present? %>
-      <div class="row mt-4">
+      <%= tag.div(data: {controller: "inline-tag-creator", inline_tag_creator_url_value: tags_path}, class: "row mt-4" ) do %>
         <div class="col-sm-3">
-          <%= form.label 'Select Tags', class: 'fw-bold' %>
-        </div>
-        <div class="col-sm-9">
-          <%= form.collection_check_boxes :tag_ids, tags, :id, :name do |r| %>
-            <div class='form-check'>
-              <%= r.check_box class: 'form-check-input' %>
-              <%= r.label class: 'form-check-label' do %>
-                <%= r.object.name %>
-              <% end %>
-            </div>
+          <p class="fw-bold mb-1">Select Tags</p>
+          <div class="field">
+            <%= tag.input(type: "text",
+                id: "new_tag_name",
+                placeholder: "new tag",
+                class: "form-control",
+                data: { inline_tag_creator_target: "input", action: "keydown.enter->inline-tag-creator#createTag" },
+                autocomplete: "off") %>
+            <div id="inline-tag-error" class="text-danger small mt-1"></div>
+          </div>
+          <%= tag.button(type: "button", data: { action: "click->inline-tag-creator#createTag" }, class: "#{button_classes} mt-2") do %>
+            Add Tag
           <% end %>
         </div>
-      </div>
+        <div class="col-sm-9">
+          <div id="js_recipe_tags_list">
+            <%= form.collection_check_boxes :tag_ids, tags, :id, :name do |r| %>
+              <div class="form-check">
+                <%= r.check_box class: 'form-check-input' %>
+                <%= r.label class: 'form-check-label' do %>
+                  <%= r.object.name %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
 
     <div class="row">

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -117,12 +117,7 @@
       <div class="col-sm-3">
         <p class="fw-bold mb-1">Select Tags</p>
         <div class="field">
-          <%= tag.input(type: "text",
-              id: "new_tag_name",
-              placeholder: "new tag",
-              class: "form-control",
-              data: { inline_tag_creator_target: "input", action: "keydown.enter->inline-tag-creator#createTag" },
-              autocomplete: "off") %>
+          <%= render partial: 'form_new_tag_field' %>
           <div id="js_inline_tag_error" class="text-danger small mt-1"></div>
         </div>
         <%= tag.button(type: "button", data: { action: "click->inline-tag-creator#createTag" }, class: "#{button_classes} mt-2") do %>

--- a/app/views/recipes/_form_new_tag_field.erb
+++ b/app/views/recipes/_form_new_tag_field.erb
@@ -1,0 +1,11 @@
+<%= tag.input(
+    type: "text",
+    id: "js_recipe_form_new_tag_field",
+    placeholder: "new tag",
+    class: "form-control",
+    data: {
+            inline_tag_creator_target: "input",
+            action: "keydown.enter->inline-tag-creator#createTag"
+          },
+    autocomplete: "off"
+) %>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: tag) do |form| %>
+<%= form_with(model: tag, data: { turbo: false }) do |form| %>
   <%= render 'shared/errors', object: tag %>
 
   <div class='row'>

--- a/app/views/tags/create.turbo_stream.erb
+++ b/app/views/tags/create.turbo_stream.erb
@@ -14,6 +14,7 @@
     </div>
   <% end %>
   <%= turbo_stream.update "js_inline_tag_error", "" %>
+  <%= turbo_stream.replace "js_recipe_form_new_tag_field", partial: '/recipes/form_new_tag_field' %>
 <% else %>
   <%= turbo_stream.update "js_inline_tag_error" do %>
     <%= @tag.errors.full_messages.to_sentence %>

--- a/app/views/tags/create.turbo_stream.erb
+++ b/app/views/tags/create.turbo_stream.erb
@@ -1,0 +1,21 @@
+<% if @tag.persisted? %>
+  <%= turbo_stream.append "js_recipe_tags_list" do %>
+    <div class="form-check">
+      <%= tag.input(
+          type: "checkbox",
+          class: "form-check-input",
+          name: "recipe[tag_ids][]",
+          id: "recipe_tag_ids_#{@tag.id}",
+          value: @tag.id,
+          checked: true) %>
+      <%= tag.label(for: "recipe_tag_ids_#{@tag.id}", class: "form-check-label") do %>
+        <%= @tag.name %>
+      <% end %>
+    </div>
+  <% end %>
+  <%= turbo_stream.update "inline-tag-error", "" %>
+<% else %>
+  <%= turbo_stream.update "inline-tag-error" do %>
+    <%= @tag.errors.full_messages.to_sentence %>
+  <% end %>
+<% end %>

--- a/app/views/tags/create.turbo_stream.erb
+++ b/app/views/tags/create.turbo_stream.erb
@@ -13,9 +13,9 @@
       <% end %>
     </div>
   <% end %>
-  <%= turbo_stream.update "inline-tag-error", "" %>
+  <%= turbo_stream.update "js_inline_tag_error", "" %>
 <% else %>
-  <%= turbo_stream.update "inline-tag-error" do %>
+  <%= turbo_stream.update "js_inline_tag_error" do %>
     <%= @tag.errors.full_messages.to_sentence %>
   <% end %>
 <% end %>

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -93,6 +93,34 @@ RSpec.describe "Tags", type: :request do
       post tags_path(tag: tag_attributes)
 
       expect(Tag.count).to eq(starting_count + 1)
+      expect(response).to redirect_to(tags_url)
+    end
+
+    it "renders new with 422 on invalid tags#create" do
+      post tags_path, params: {tag: {name: ""}}
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(:new)
+    end
+
+    it "creates tag and returns turbo stream on tags#create" do
+      tag_attributes = build(:tag, user: user).attributes
+
+      expect {
+        post tags_path, params: {tag: tag_attributes}, headers: {"Accept" => "text/vnd.turbo-stream.html"}
+      }.to change(Tag, :count).by(1)
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    end
+
+    it "returns 422 turbo stream on invalid tags#create" do
+      expect {
+        post tags_path, params: {tag: {name: ""}}, headers: {"Accept" => "text/vnd.turbo-stream.html"}
+      }.not_to change(Tag, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
     end
 
     it "renders tags#update" do


### PR DESCRIPTION
## Related Issues & PRs
Closes #1125 
Wrote blog post about it: https://lortza.github.io/2026/04/14/add-tags-from-parent-form.html

## Changes Made
### `inline_tag_creator_controller.js`
  - Imports post from `@rails/request.js` — CSRF token is handled automatically
  - add action `POST`s `{ tag: { name } }` with `responseKind: "turbo-stream"`, which tells request.js to set the right `Accept` header and auto-process the stream response

### `tags_controller.rb`
  - create now uses `respond_to` with both `format.html` (unchanged behavior) and `format.turbo_stream` (new)
  - Failure renders the same template with a `422 status — response.ok` in Stimulus will be false, so the input won't clear

### `create.turbo_stream.erb`
  - On success (`@tag.persisted?`): appends a pre-checked checkbox to `#js_recipe_tags_list`, clear the input field, and clears `#js_inline_tag_error`
  - On failure: updates `#js_inline_tag_error` with the validation message (e.g. "Name has already been taken")

### `_form.html.erb`
  - The text input has no name attribute so it doesn't pollute the recipe form params
  - `type="button"` prevents the outer recipe form from submitting on click
  - `keydown.enter->inline-tag-creator#createTag` lets the user press Enter in the input to add a tag
  - Removed the <% if tags.present? %> guard so users can add tags if they want to

## This PR Does Not
* change the functionality of managing tags the old way
* add any new styles to the tags in the recipe form

## Screenshots
![new_tags](https://github.com/user-attachments/assets/b6c240f5-3d14-4a46-a8e4-2e7ee8b5e565)


## Things Learned
* `gem "requestjs-rails"` is a pretty handy workaround for this kind of situation

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I updated the README with new/changed features
- [ ] I updated `CLAUDE.md` with crucial working details
- [x] I have written new specs for this work
- [x] I have browser tested this work locally
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
