### PR TITLE
Remove unused function

### DIFF
--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -13,11 +13,4 @@ export default class extends Controller {
       this.element.requestSubmit()
     }, 300)
   }
-
-  clear() {
-    if (this.hasInputTarget) {
-      this.inputTarget.value = ""
-    }
-    this.element.requestSubmit()
-  }
 }


### PR DESCRIPTION
## This PR Does
* removes an unused function from a stimulus controller

The `clear` function was doing this:
  - If the controller has an input target, it empties the input's value `(this.inputTarget.value = "")`.
  - Then triggers a form submission via `this.element.requestSubmit()` (re-running the search with an empty query, effectively resetting results).

Now the field is being cleared via the turbo response.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I updated the README with new/changed features
- [x] I updated `CLAUDE.md` with crucial working details
- [ ] I have written new specs for this work
- [x] I have browser tested this work locally
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
