### PR TITLE
Replace blank link with div as DOM element

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -108,7 +108,8 @@
           <% end %>
         </template>
       </div>
-      <%= link_to '#', data: { action: "click->add-ingredient-fields#append" }, class: button_classes("warning float-end mt-2") do %>
+
+      <%= tag.div(data: { action: "click->add-ingredient-fields#append" }, class: button_classes("warning float-end mt-2")) do %>
         <%= MaterialIcon.new(icon: :plus_circle, title: 'Add ingredient').render %>  Add ingredient
       <% end %>
     </div>


### PR DESCRIPTION
## Related Issues & PRs
I missed this detail in the refactor #1273.

## This PR Does
* Replaces an unnecessary `<a>` tag (`link_to`) with a simple `<div>` as the DOM element to receive a user's click.

## This PR Does Not
* Change any functionality of the feature


## Due Diligence Checks
| done | n/a | Item |
|-----|-----|-----|
|   |x | If this work contains migrations, I have updated factories and seeds accordingly |
|   | x | I updated the README with new/changed features |
|   |  x | I updated `CLAUDE.md` with crucial working details |
|   |  x | I have written new specs for this work |
|  x |   | I have browser tested this work locally |
|  x |   | I have reviewed this PR |
|  x |   | I have deployed the feature branch to production and browser tested it successfully |
 
