### PR TITLE
Fix strikethrough bug on recipe instruction tab titles

### DIFF
--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -54,7 +54,7 @@
     <div class='row'>
       <div class='col-sm-12'>
         <h3>Instructions</h3>
-        <div class="card mb-5" data-controller="toggle-strikethrough" data-action="click->toggle-strikethrough#toggle" data-toggle-strikethrough-element-value="li">
+        <div class="card mb-5">
           <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs">
               <li class="nav-item">
@@ -68,7 +68,7 @@
               </li>
             </ul>
           </div>
-          <div class="card-body">
+          <div class="card-body" data-controller="toggle-strikethrough" data-action="click->toggle-strikethrough#toggle" data-toggle-strikethrough-element-value="li">
             <div class="tab-content" id="myTabContent">
               <div class="tab-pane fade show active" id="prep-day" role="tabpanel" aria-labelledby="prep-day-tab">
                 <ol>


### PR DESCRIPTION
## The Bug
When clicking on the recipe instruction headings, they were toggling their strikethrough behavior in the same way that the instruction line items are expected to. The headings should never be crossed off.

<img width="1260" height="828" alt="before" src="https://github.com/user-attachments/assets/7850e2f8-3051-4813-b3b0-3683025f8f61" />


## The Fix
The strikethrough Stimulus controller was too high up in the HTML and therefore creating a larger context than it needed. I moved the controller down to the smallest context so that the behavior was limited to just the instruction list items.

<img width="1260" height="828" alt="after" src="https://github.com/user-attachments/assets/b1b9944b-38b8-48d0-9420-e0b2cc1e435c" />


## Due Diligence Checks
| done | n/a | Item |
|-----|-----|-----|
|  | x | If this work contains migrations, I have updated factories and seeds accordingly |
|  |  x| I updated the README with new/changed features |
|  |  x| I updated `CLAUDE.md` with crucial working details |
|  |  x| I have written new specs for this work |
| x |  | I have browser tested this work locally |
| x |  | I have reviewed this PR |
|  | x | I have deployed the feature branch to production and browser tested it successfully |
