### PR TITLE
Scale recipe ingredients (½×/1×/2×) on the show page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Live on heroku as [myfoodplanner](http://myfoodplanner.herokuapp.com)
   - Archive recipes you no longer care to see in your list
   - Share a recipe with a friend
   - Dynamically add ingredient lines to recipe form for long recipes ([PR #1276](https://github.com/lortza/food_planner/pull/1267))
+  - Scale recipes' ingredients to 1/2x or 2x ([PR #1318](https://github.com/lortza/food_planner/pull/1318))
 - Recipe Suggestions Based on Ingredient Inventory
   - Enter an inventory of ingredients and get a list of recipe suggestions ([PR #237](https://github.com/lortza/food_planner/pull/237))
 - Meal Planning

--- a/app/helpers/ingredients_helper.rb
+++ b/app/helpers/ingredients_helper.rb
@@ -36,25 +36,24 @@ module IngredientsHelper
   private
 
   def process_fraction(number)
-    if known_fraction(number)
-      known_fraction(number)
-    elsif number.between?(0.3, 0.4)
-      known_fraction(0.33)
-    elsif number.between?(0.6, 0.7)
-      known_fraction(0.66)
-    else
-      number.round(3)
-    end
+    # Use an exact known fraction (e.g. 0.5), otherwise round the value down to
+    # two decimal places and try again (e.g. 0.6666 -> 0.66 -> "2/3"). Anything
+    # that still has no known fraction falls back to a rounded decimal.
+    known_fraction(number) || known_fraction(number.floor(2)) || number.round(3)
   end
 
   def known_fraction(number)
     fractions = {
+      0.0625 => "1/16",
       0.125 => "1/8",
       0.25 => "1/4",
       0.33 => "1/3",
+      0.375 => "3/8",
       0.5 => "1/2",
+      0.625 => "5/8",
       0.66 => "2/3",
-      0.75 => "3/4"
+      0.75 => "3/4",
+      0.875 => "7/8"
     }
     fractions[number]
   end

--- a/app/helpers/ingredients_helper.rb
+++ b/app/helpers/ingredients_helper.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 module IngredientsHelper
-  def ingredient_display(ingredient)
+  def ingredient_display(ingredient:, multiplier: 1)
+    quantity = ingredient.quantity * multiplier
     display_name = if Ingredient::DESCRIPTIVE_UNITS.include?(ingredient.measurement_unit)
-      pluralize(qty_display(ingredient), "#{ingredient.measurement_unit} #{ingredient.name}")
+      pluralize(qty_display(quantity), "#{ingredient.measurement_unit} #{ingredient.name}")
     else
-      "#{pluralize(qty_display(ingredient), ingredient.measurement_unit)} #{ingredient.name}"
+      "#{pluralize(qty_display(quantity), ingredient.measurement_unit)} #{ingredient.name}"
     end
 
     return "#{display_name}: #{ingredient.preparation_style}" if ingredient.preparation_style.present?
@@ -15,9 +16,9 @@ module IngredientsHelper
 
   def detail_display(detail)
     pluralized = if Ingredient::DESCRIPTIVE_UNITS.include?(detail.measurement_unit)
-      "#{qty_display(detail)} #{detail.measurement_unit}"
+      "#{qty_display(detail.quantity)} #{detail.measurement_unit}"
     else
-      pluralize(qty_display(detail), detail.measurement_unit)
+      pluralize(qty_display(detail.quantity), detail.measurement_unit)
     end
 
     [
@@ -26,10 +27,10 @@ module IngredientsHelper
     ].compact.join(" ")
   end
 
-  def qty_display(ingredient)
-    return ingredient.quantity.to_i if NumbersHelper.whole_number?(ingredient.quantity)
+  def qty_display(quantity)
+    return quantity.to_i if NumbersHelper.whole_number?(quantity)
 
-    process_fraction(ingredient.quantity)
+    process_fraction(quantity)
   end
 
   private

--- a/app/javascript/controllers/scale_recipe_ingredients_controller.js
+++ b/app/javascript/controllers/scale_recipe_ingredients_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["button", "js_half_scale", "js_full_scale", "js_double_scale"]
 
-  select() {
+  select(event) {
     // remove active from all buttons, set the clicked one active
     this.buttonTargets.forEach((button) => button.classList.remove("active"))
     event.currentTarget.classList.add("active")
@@ -14,6 +14,5 @@ export default class extends Controller {
     this.js_double_scaleTarget.classList.add("hidden")
 
     this[`${event.params.list}Target`].classList.remove("hidden")
-
   }
 }

--- a/app/javascript/controllers/scale_recipe_ingredients_controller.js
+++ b/app/javascript/controllers/scale_recipe_ingredients_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "js_half_scale", "js_full_scale", "js_double_scale"]
+
+  select() {
+    // remove active from all buttons, set the clicked one active
+    this.buttonTargets.forEach((button) => button.classList.remove("active"))
+    event.currentTarget.classList.add("active")
+
+    // hide all lists explicitly, then show the one this button names
+    this.js_half_scaleTarget.classList.add("hidden")
+    this.js_full_scaleTarget.classList.add("hidden")
+    this.js_double_scaleTarget.classList.add("hidden")
+
+    this[`${event.params.list}Target`].classList.remove("hidden")
+
+  }
+}

--- a/app/views/meal_plans/prep_day.html.erb
+++ b/app/views/meal_plans/prep_day.html.erb
@@ -57,7 +57,7 @@
         <p><%= recipe.notes %></p>
       <% end %>
 
-      <%= render partial: "recipes/ingredients_section", locals: {recipe: recipe} %>
+      <%= render partial: "recipes/ingredients_section", locals: {ingredients: recipe.ingredients.by_id} %>
 
       <h3>Instructions</h3>
       <div class="card mb-5" data-controller="toggle-strikethrough" data-action="click->toggle-strikethrough#toggle" data-toggle-strikethrough-element-value="li">

--- a/app/views/meal_plans/prep_day.html.erb
+++ b/app/views/meal_plans/prep_day.html.erb
@@ -57,13 +57,7 @@
         <p><%= recipe.notes %></p>
       <% end %>
 
-      <h3>Ingredients</h3>
-      <div class='ms-3 mb-4'>
-        <% recipe.ingredients.by_id.each do |ingredient| %>
-          <input type="checkbox">
-          <label class="mb-0 inline"><%= ingredient_display(ingredient) %></label><br>
-        <% end %>
-      </div>
+      <%= render partial: "recipes/ingredients_section", locals: {recipe: recipe} %>
 
       <h3>Instructions</h3>
       <div class="card mb-5" data-controller="toggle-strikethrough" data-action="click->toggle-strikethrough#toggle" data-toggle-strikethrough-element-value="li">

--- a/app/views/recipes/_ingredients_list.html.erb
+++ b/app/views/recipes/_ingredients_list.html.erb
@@ -1,4 +1,4 @@
-<% recipe.ingredients.by_id.each do |ingredient| %>
+<% ingredients.each do |ingredient| %>
   <input type="checkbox">
   <label class="mb-0 inline"><%= ingredient_display(ingredient: ingredient, multiplier: multiplier) %></label><br>
 <% end %>

--- a/app/views/recipes/_ingredients_list.html.erb
+++ b/app/views/recipes/_ingredients_list.html.erb
@@ -1,0 +1,4 @@
+<% recipe.ingredients.by_id.each do |ingredient| %>
+  <input type="checkbox">
+  <label class="mb-0 inline"><%= ingredient_display(ingredient: ingredient, multiplier: multiplier) %></label><br>
+<% end %>

--- a/app/views/recipes/_ingredients_section.html.erb
+++ b/app/views/recipes/_ingredients_section.html.erb
@@ -30,15 +30,15 @@
 
   <div id="ingredients" class='ms-3 mb-4'>
     <%= tag.div class: "hidden", data: {"scale-recipe-ingredients-target": "js_half_scale"} do %>
-      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 0.5} %>
+      <%= render partial: "recipes/ingredients_list", locals: {ingredients: ingredients, multiplier: 0.5} %>
     <% end %>
 
     <%= tag.div data: {"scale-recipe-ingredients-target": "js_full_scale"} do %>
-      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 1} %>
+      <%= render partial: "recipes/ingredients_list", locals: {ingredients: ingredients, multiplier: 1} %>
     <% end %>
 
     <%= tag.div class: "hidden", data: {"scale-recipe-ingredients-target": "js_double_scale"} do %>
-      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 2} %>
+      <%= render partial: "recipes/ingredients_list", locals: {ingredients: ingredients, multiplier: 2} %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/recipes/_ingredients_section.html.erb
+++ b/app/views/recipes/_ingredients_section.html.erb
@@ -1,0 +1,44 @@
+<h3>Ingredients</h3>
+
+<%= tag.div data: {controller: "scale-recipe-ingredients"} do %>
+  <p class="d-inline-flex gap-1">
+    <%= tag.button type: "button", class: "fw-bold btn",
+      data: {
+        bs_toggle: "button",
+        "scale-recipe-ingredients-target": "button",
+        action: "scale-recipe-ingredients#select",
+        "scale-recipe-ingredients-list-param": "js_half_scale" } do %>
+      &frac12;x
+    <% end %>
+    <%= tag.button type: "button", class: "fw-bold btn active",
+      data: {
+        bs_toggle: "button",
+        "scale-recipe-ingredients-target": "button",
+        action: "scale-recipe-ingredients#select",
+        "scale-recipe-ingredients-list-param": "js_full_scale" } do %>
+      1x
+    <% end %>
+    <%= tag.button type: "button", class: "fw-bold btn",
+      data: {
+        bs_toggle: "button",
+        "scale-recipe-ingredients-target": "button",
+        action: "scale-recipe-ingredients#select",
+        "scale-recipe-ingredients-list-param": "js_double_scale" } do %>
+      2x
+    <% end %>
+  </p>
+
+  <div id="ingredients" class='ms-3 mb-4'>
+    <%= tag.div class: "hidden", data: {"scale-recipe-ingredients-target": "js_half_scale"} do %>
+      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 0.5} %>
+    <% end %>
+
+    <%= tag.div data: {"scale-recipe-ingredients-target": "js_full_scale"} do %>
+      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 1} %>
+    <% end %>
+
+    <%= tag.div class: "hidden", data: {"scale-recipe-ingredients-target": "js_double_scale"} do %>
+      <%= render partial: "recipes/ingredients_list", locals: {recipe: recipe, multiplier: 2} %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -30,15 +30,9 @@
   <!-- Left side content -->
   <div class='col-md-8 col-sm-12'>
     <div class='row'>
-      <div class='col-md-6 col-sm-12'>
-       <h3>Ingredients</h3>
-        <div class='ms-3 mb-4'>
-          <% @recipe.ingredients.by_id.each do |ingredient| %>
-            <input type="checkbox">
-            <label class="mb-0 inline"><%= ingredient_display(ingredient) %></label><br>
-          <% end %>
-        </div>
-      </div> <!-- col-6 -->
+      <div class="col-md-6 col-sm-12">
+        <%= render partial: "recipes/ingredients_section", locals: {recipe: @recipe} %>
+      </div>
 
       <div class='col-md-6 col-sm-12'>
         <% if @recipe.extra_work_required? %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -31,7 +31,7 @@
   <div class='col-md-8 col-sm-12'>
     <div class='row'>
       <div class="col-md-6 col-sm-12">
-        <%= render partial: "recipes/ingredients_section", locals: {recipe: @recipe} %>
+        <%= render partial: "recipes/ingredients_section", locals: {ingredients: @recipe.ingredients.by_id} %>
       </div>
 
       <div class='col-md-6 col-sm-12'>

--- a/spec/helpers/ingredients_helper_spec.rb
+++ b/spec/helpers/ingredients_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IngredientsHelper, type: :helper do
         quantity: 1,
         name: "water")
       expected_output = "1 cup water"
-      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+      expect(helper.ingredient_display(ingredient: ingredient)).to eq(expected_output)
     end
 
     it "pluralizes the unit when it is a standard unit" do
@@ -19,7 +19,7 @@ RSpec.describe IngredientsHelper, type: :helper do
         quantity: 2,
         name: "water")
       expected_output = "2 cups water"
-      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+      expect(helper.ingredient_display(ingredient: ingredient)).to eq(expected_output)
     end
 
     it "pluralizes the name when the unit is a descriptive unit" do
@@ -28,7 +28,7 @@ RSpec.describe IngredientsHelper, type: :helper do
         quantity: 2,
         name: "carrot")
       expected_output = "2 whole carrots"
-      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+      expect(helper.ingredient_display(ingredient: ingredient)).to eq(expected_output)
     end
 
     it "if present, displays the preparation_style" do
@@ -38,7 +38,17 @@ RSpec.describe IngredientsHelper, type: :helper do
         quantity: 3,
         name: "garlic")
       expected_output = "3 cloves garlic: minced"
-      expect(helper.ingredient_display(ingredient)).to eq(expected_output)
+      expect(helper.ingredient_display(ingredient: ingredient)).to eq(expected_output)
+    end
+
+    it "if present, it multiplies the quantity by a multiplier" do
+      ingredient = build(:ingredient,
+        preparation_style: "minced",
+        measurement_unit: "clove",
+        quantity: 3,
+        name: "garlic")
+      expected_output = "1.5 cloves garlic: minced"
+      expect(helper.ingredient_display(ingredient: ingredient, multiplier: 0.5)).to eq(expected_output)
     end
   end
 
@@ -97,27 +107,27 @@ RSpec.describe IngredientsHelper, type: :helper do
   describe "qty_display" do
     it "displays whole numbers as integers" do
       ingredient = build(:ingredient, quantity: 1)
-      expect(helper.qty_display(ingredient)).to eq(1)
+      expect(helper.qty_display(ingredient.quantity)).to eq(1)
     end
 
     it "displays known fractions as fractions" do
       ingredient = build(:ingredient, quantity: 0.125)
-      expect(helper.qty_display(ingredient)).to eq("1/8")
+      expect(helper.qty_display(ingredient.quantity)).to eq("1/8")
     end
 
     it "handles 1/3 gracefully" do
       ingredient = build(:ingredient, quantity: 0.3)
-      expect(helper.qty_display(ingredient)).to eq("1/3")
+      expect(helper.qty_display(ingredient.quantity)).to eq("1/3")
     end
 
     it "handles 1/6 gracefully" do
       ingredient = build(:ingredient, quantity: 0.6)
-      expect(helper.qty_display(ingredient)).to eq("2/3")
+      expect(helper.qty_display(ingredient.quantity)).to eq("2/3")
     end
 
     it "rounds other unknown floats to 3 places" do
       ingredient = build(:ingredient, quantity: 0.711765)
-      expect(helper.qty_display(ingredient)).to eq(0.712)
+      expect(helper.qty_display(ingredient.quantity)).to eq(0.712)
     end
   end
 end

--- a/spec/helpers/ingredients_helper_spec.rb
+++ b/spec/helpers/ingredients_helper_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe IngredientsHelper, type: :helper do
       expected_output = "1.5 cloves garlic: minced"
       expect(helper.ingredient_display(ingredient: ingredient, multiplier: 0.5)).to eq(expected_output)
     end
+
+    it "doubles the quantity with a multiplier of 2" do
+      ingredient = build(:ingredient,
+        measurement_unit: "cup",
+        quantity: 1,
+        name: "water")
+      expected_output = "2 cups water"
+      expect(helper.ingredient_display(ingredient: ingredient, multiplier: 2)).to eq(expected_output)
+    end
   end
 
   describe "detail_display" do
@@ -116,12 +125,12 @@ RSpec.describe IngredientsHelper, type: :helper do
     end
 
     it "handles 1/3 gracefully" do
-      ingredient = build(:ingredient, quantity: 0.3)
+      ingredient = build(:ingredient, quantity: 0.3333)
       expect(helper.qty_display(ingredient.quantity)).to eq("1/3")
     end
 
-    it "handles 1/6 gracefully" do
-      ingredient = build(:ingredient, quantity: 0.6)
+    it "handles 2/3 gracefully" do
+      ingredient = build(:ingredient, quantity: 0.66666)
       expect(helper.qty_display(ingredient.quantity)).to eq("2/3")
     end
 


### PR DESCRIPTION
## This PR Does
* Adds ½×/1×/2× scaling buttons to the recipe show page ingredient list. Clicking a button shows that scale's ingredient quantities and marks the button active. **Display-only — no persisted recipe data changes.**
* Pre-renders all three scaled lists server-side and toggles visibility with a new `scale-recipe-ingredients` Stimulus controller.
* Extracts the ingredient markup into two partials — `recipes/_ingredients_section` (buttons + the three scaled lists) and `recipes/_ingredients_list` (the rows) — and reuses the section on `meal_plans/prep_day`.
* Reworks `ingredient_display` to take keyword args `(ingredient:, multiplier:)` and scale the quantity; `qty_display` now takes a raw quantity number instead of an ingredient.
* Simplifies `process_fraction`: use an exact known fraction, else round the value **down to two decimals** and try again (`0.6666 → 0.66 → "2/3"`), else fall back to a rounded decimal. This also fixes a latent bug where the old `0.3–0.4` band returned `"3/8"` instead of `"1/3"`.

## This PR Does Not
* Does not persist scaled quantities — scaling lives entirely in the view.
* Does not share checkbox (checked) state across the three scale lists; switching scale resets checks.
* Does not add mixed-number formatting (e.g. `1.5` displays as `1.5`, not `1 1/2`).
* Does not add a JS/system test for the Stimulus toggle behavior (helper logic is unit-tested).

## Screenshots
On recipe show page
<img width="1260" height="828" alt="recipe show" src="https://github.com/user-attachments/assets/af9c545d-ae8f-410e-9dc1-85a2bba0be13" />

On prep day page
<img width="1260" height="828" alt="prep_day" src="https://github.com/user-attachments/assets/0f65d0f3-460c-4ab4-b21c-fdcd06938c37" />


## Things Learned
* **Approach choice:** Pre-rendering all three scales server-side reuses the existing fraction + pluralization helper as the single source of truth, avoiding re-implementing that logic in JS (the client-side-math option) or paying a round-trip per click (the Turbo Frame option).
* **Stimulus params vs values:** Each button *hardcodes* the list it controls via an action param (`data-…-list-param`), read as `event.params.list`. Params are per-element click data, which fits better than Values (controller-level state). The controller resolves the target dynamically via `this[\`${event.params.list}Target\`]`.
* **One query, not three:** Passing a single `ingredients` relation down to all three list partials means it loads once (ActiveRecord relation result caching) instead of issuing the query three times.
* `Float#floor(2)` is a clean way to snap repeating decimals (`0.3333`, `0.6666`) to known fractions without hardcoded `between?` bands.

## Due Diligence Checks
| done | n/a | Item |
|-----|-----|-----|
|  | x | If this work contains migrations, I have updated factories and seeds accordingly |
| x |  | I updated the README with new/changed features |
|  | x | I updated `CLAUDE.md` with crucial working details |
| x |  | I have written new specs for this work |
|x |  | I have browser tested this work locally |
| x |  | I have reviewed this PR |
|  |  | I have deployed the feature branch to production and browser tested it successfully |

🤖 Generated with [Claude Code](https://claude.com/claude-code)