### PR TITLE
Validate source_url/image_url schemes and harden source links

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -54,6 +54,7 @@ class Recipe < ApplicationRecord
   has_many :tags, through: :recipe_tags
 
   DEFAULT_SOURCE = {source_name: "Original Creation", source_url: "/"}.freeze
+  ALLOWED_URL_SCHEMES = %w[http https].freeze
   DEFAULT_PARAMS = {
     prep_time: 10,
     cook_time: 20,
@@ -65,6 +66,12 @@ class Recipe < ApplicationRecord
 
   validates :title, :source_url, presence: true
   validates :title, uniqueness: {scope: :user_id, case_sensitive: false}
+
+  # Runs for all statuses, including pending: these URLs are rendered as links
+  # and image sources, so a disallowed scheme (e.g. javascript:, data:) must be
+  # rejected even before a recipe is finalized. See issue #1319.
+  validate :source_url_scheme_allowed
+  validate :image_url_scheme_allowed
 
   # These validations are skipped if the recipe is pending, but run for all other statuses
   with_options unless: :pending? do
@@ -106,6 +113,14 @@ class Recipe < ApplicationRecord
     self.source_url = DEFAULT_SOURCE[:source_url] if source_url.blank?
   end
 
+  def source_url_scheme_allowed
+    validate_url_scheme(:source_url)
+  end
+
+  def image_url_scheme_allowed
+    validate_url_scheme(:image_url)
+  end
+
   def guarantee_instructions_values
     return false if prep_day_instructions.blank? && instructions.blank?
 
@@ -136,6 +151,22 @@ class Recipe < ApplicationRecord
   end
 
   private
+
+  # Allows blank values and the "/" relative default; otherwise the URL must
+  # parse and use an http/https scheme. Blocks javascript:, data:, file:, and
+  # protocol-relative ("//host") values before they are rendered.
+  def validate_url_scheme(attribute)
+    value = self[attribute]
+    return if value.blank?
+    return if value == DEFAULT_SOURCE[:source_url]
+
+    scheme = URI.parse(value).scheme&.downcase
+    unless ALLOWED_URL_SCHEMES.include?(scheme)
+      errors.add(attribute, "must be a valid http or https URL")
+    end
+  rescue URI::InvalidURIError
+    errors.add(attribute, "is not a valid URL")
+  end
 
   def update_recipe_last_prepared_on(meal_plan)
     update(last_prepared_on: meal_plans.maximum(:prepared_on))

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -138,7 +138,7 @@
       <%= form.label 'Original Instructions*', class: 'fw-bold mt-3' %>
       <% if recipe.source_url.present? %>
         <%= form.label class: 'fw-bold mt-5' do %>
-          <%= link_to recipe.source_url, target: '_blank' do %>
+          <%= link_to recipe.source_url, target: '_blank', rel: 'noopener noreferrer' do %>
             <%= MaterialIcon.new(icon: :open_in_new, title: "View source recipe").render %>
           <% end %>
         <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -10,7 +10,7 @@
       <sup><%= extra_work_flag(@recipe) if current_user.present? %> <%= status_flag(@recipe) %></sup>
     </h1>
     <div class='recipe-show-stats text-small'>
-      <div>Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank' %></div>
+      <div>Source: <%= link_to @recipe.source_name, @recipe.source_url, title: @recipe.source_name, target: '_blank', rel: 'noopener noreferrer' %></div>
       <div>Servings: <%= @recipe.servings %></div>
       <div>Prep Time: <%= display_time(@recipe.prep_time) %></div>
       <div>Cook Time: <%= display_time(@recipe.cook_time) %></div>

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -127,6 +127,56 @@ RSpec.describe Recipe, type: :model do
       end
     end
 
+    describe "url scheme validation" do
+      it "is valid with an http source_url" do
+        recipe = build(:recipe, source_url: "http://example.com/recipe")
+        expect(recipe).to be_valid
+      end
+
+      it "is valid with an https source_url" do
+        recipe = build(:recipe, source_url: "https://example.com/recipe")
+        expect(recipe).to be_valid
+      end
+
+      it "is valid with the '/' default source_url" do
+        recipe = build(:recipe, source_url: "/")
+        expect(recipe).to be_valid
+      end
+
+      it "is valid with a blank image_url" do
+        recipe = build(:recipe, image_url: "")
+        expect(recipe).to be_valid
+      end
+
+      it "is invalid with a javascript: scheme in source_url" do
+        recipe = build(:recipe, source_url: "javascript:alert(1)")
+        expect(recipe).to_not be_valid
+        expect(recipe.errors[:source_url]).to be_present
+      end
+
+      it "is invalid with a javascript: scheme in image_url" do
+        recipe = build(:recipe, image_url: "javascript:alert(1)")
+        expect(recipe).to_not be_valid
+        expect(recipe.errors[:image_url]).to be_present
+      end
+
+      it "is invalid with a data: scheme in image_url" do
+        recipe = build(:recipe, image_url: "data:text/html,<script>alert(1)</script>")
+        expect(recipe).to_not be_valid
+      end
+
+      it "is invalid with a protocol-relative source_url" do
+        recipe = build(:recipe, source_url: "//evil.example.com")
+        expect(recipe).to_not be_valid
+      end
+
+      it "rejects a disallowed scheme even when the recipe is pending" do
+        recipe = build(:recipe, status: :pending, source_url: "javascript:alert(1)")
+        expect(recipe).to_not be_valid
+        expect(recipe.errors[:source_url]).to be_present
+      end
+    end
+
     describe "title uniqueness" do
       let(:user_1) { create(:user) }
       let(:user_2) { create(:user) }


### PR DESCRIPTION
## Related Issues & PRs
Builds on the SSRF work in #1309.

## This PR Does
* **Adds model-level scheme validation** for `source_url` and `image_url`: each must be blank, the `"/"` default sentinel, or a parseable `http`/`https` URL. Disallowed schemes (`javascript:`, `data:`, `file:`) and protocol-relative `//host` values are rejected.
* **Runs that validation for all statuses, including `pending`** — it sits outside the `unless: :pending?` block, because pending recipes are still rendered as links/image sources.
* **Adds `rel="noopener noreferrer"`** to the two `target="_blank"` source links (`show.html.erb`, `_form.html.erb`).
* Adds model specs covering the valid/invalid scheme cases and the pending-still-validates case.

## This PR Does Not
* Does not add a Content Security Policy (#1313 item 3).
* Does not add the `image_url` server-side-fetch guard rail comment (#1319 item 4).
* Does not close the DNS-rebinding / TOCTOU gap (#1310).
* Does not retroactively scrub `source_url`/`image_url` values already stored before this validation existed.


## How this improves security
* **Closes a stored XSS vector.** `link_to` does not filter the href scheme, so a recipe saved with `source_url = "javascript:…"` previously rendered a clickable `<a href="javascript:…">`. Because recipes are shareable/duped across users, that was stored XSS with cross-user reach. The scheme allowlist now rejects it at persistence — and crucially for *all* statuses, since the body-paste flow can persist a `source_url` that is never fetched (so `UrlSafetyValidator` never sees it) but is still rendered.
* **Prevents reverse tabnabbing + referrer leakage.** The `target="_blank"` source links now carry `rel="noopener noreferrer"`, so the user-controlled destination page can no longer reach `window.opener` to redirect the original tab, and the app URL no longer leaks via referrer.
* **Reduces mixed-content / weird-scheme surface** for `image_url` by requiring http/https.

## Remaining security gaps (still open)
* **DNS rebinding / TOCTOU (#1310):** `UrlSafetyValidator` resolves the host at validation time, but HTTParty re-resolves at connect time — a host can flip to a private address in between. Closing it needs connection-level IP pinning.
* **No Content Security Policy (#1319 item 3):** a CSP would be defense-in-depth against both the link-XSS and the `image_url` privacy/tracking-leak angle (external images leak each viewer's IP/UA).
* **Pre-existing data:** any `source_url`/`image_url` persisted before this PR is not re-validated; a data audit/backfill is not included.

## Things Learned
* Rails `link_to` does **not** sanitize the href scheme — `javascript:`/`data:` pass straight through, so scheme validation has to happen at the model layer, not just at fetch time.
* Validating a URL only at *fetch* time misses the render path entirely; the body-paste creation flow can store a URL that is rendered but never fetched.
* `URI.parse(...).scheme` must be downcased before allowlist comparison, and `URI::InvalidURIError` must be rescued for malformed input.

## Due Diligence Checks
| done | n/a | Item |
|-----|-----|-----|
|  | x | If this work contains migrations, I have updated factories and seeds accordingly |
|  | x | I updated the README with new/changed features |
|  | x | I updated `CLAUDE.md` with crucial working details |
| x |  | I have written new specs for this work |
|  x|  | I have browser tested this work locally |
| x |  | I have reviewed this PR |
|  |  x| I have deployed the feature branch to production and browser tested it successfully |

🤖 Generated with [Claude Code](https://claude.com/claude-code)