### PR TITLE
Update CI workflow to handle gemfile lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: bin/importmap audit
@@ -49,6 +50,7 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
 
       - name: Lint code for consistent style
         run: bundle exec standardrb
@@ -84,6 +86,7 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
 
       - name: Run tests
         env:
@@ -124,6 +127,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load


### PR DESCRIPTION
## This PR Does
* Bundler 4 has stronger rules about updating the gemfile.lock
* Dependabot needs to be able to update this file
* This change should let Dependabot do its thing by breaking the cache
